### PR TITLE
docs: コマンド存在チェックの意図をコメントで明文化

### DIFF
--- a/.github/workflows/01-create-project.yml
+++ b/.github/workflows/01-create-project.yml
@@ -27,6 +27,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.PROJECT_PAT }}
       PROJECT_OWNER: ${{ github.repository_owner }}
+    # 前提: ubuntu-latest には gh (GitHub CLI) と jq がプリインストール済み
+    # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/03-add-items-to-project.yml
+++ b/.github/workflows/03-add-items-to-project.yml
@@ -45,6 +45,8 @@ jobs:
       GH_TOKEN: ${{ secrets.PROJECT_PAT }}
       PROJECT_OWNER: ${{ github.repository_owner }}
       PROJECT_NUMBER: ${{ inputs.project_number }}
+    # 前提: ubuntu-latest には gh (GitHub CLI) と jq がプリインストール済み
+    # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/_reusable-extend-project.yml
+++ b/.github/workflows/_reusable-extend-project.yml
@@ -19,6 +19,8 @@ jobs:
       GH_TOKEN: ${{ secrets.PROJECT_PAT }}
       PROJECT_OWNER: ${{ github.repository_owner }}
       PROJECT_NUMBER: ${{ inputs.project_number }}
+    # 前提: ubuntu-latest には gh (GitHub CLI) と jq がプリインストール済み
+    # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -29,6 +29,9 @@ require_env() {
 }
 
 # コマンドの存在チェック
+# ローカル実行時に親切なエラーメッセージを表示するための防御的チェック。
+# GitHub Actions の ubuntu-latest には gh・jq ともにプリインストール済みのため
+# CI 上では実質スキップされるが、ローカル環境での利便性を考慮して残している。
 # 使用例: require_command "jq" "JSON の解析に必要です。"
 require_command() {
   local cmd="$1"


### PR DESCRIPTION
## Summary

- 方針C（現状維持）を採用: `require_command` チェックはローカル実行時の UX 向上目的で残す
- `scripts/lib/common.sh` の `require_command()` 関数にコメント追加（CI上では実質不要だがローカル用に残している旨）
- 3つのワークフローファイルに `gh`/`jq` がプリインストール済みである旨のコメント追加

## Test plan

- [ ] ワークフローの YAML 構文が正しいことを確認
- [ ] コメント追加のみのため、既存の動作に影響がないことを確認

close #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)