### PR TITLE
docs: ワークフロー 01/02 に処理シーケンス図（Mermaid）を追加

### DIFF
--- a/docs/01-create-project.md
+++ b/docs/01-create-project.md
@@ -18,3 +18,31 @@
 
 > **Note:** Project の Owner はリポジトリの Owner から自動取得されます。
 > カスタムフィールド・ステータスカラム・View の定義は各スクリプト内に固定されています。カスタマイズする場合はスクリプトを直接編集してください。
+
+## 処理シーケンス
+
+```mermaid
+sequenceDiagram
+    actor User as ユーザー
+    participant WF as 01-create-project.yml
+    participant S1 as setup-github-project.sh
+    participant RW as _reusable-extend-project.yml
+    participant S2 as setup-project-fields.sh
+    participant S3 as setup-status-columns.sh
+    participant S4 as create-project-views.sh
+
+    User->>WF: workflow_dispatch（タイトル・公開範囲）
+    Note over WF: create-project ジョブ
+    WF->>S1: Project を作成
+    S1-->>WF: project_number
+
+    Note over WF: extend-project ジョブ
+    WF->>RW: project_number を渡して呼び出し
+    RW->>S2: カスタムフィールドを作成
+    S2-->>RW: 完了
+    RW->>S3: ステータスカラムを設定
+    S3-->>RW: 完了
+    RW->>S4: View を作成
+    S4-->>RW: 完了
+    RW-->>WF: 完了
+```

--- a/docs/02-extend-project.md
+++ b/docs/02-extend-project.md
@@ -15,3 +15,27 @@
 | パラメータ | 説明 | 必須 | 例 |
 |------------|------|:----:|-----|
 | `project_number` | 対象 Project の Number | ✅ | `1` |
+
+## 処理シーケンス
+
+```mermaid
+sequenceDiagram
+    actor User as ユーザー
+    participant WF as 02-extend-project.yml
+    participant RW as _reusable-extend-project.yml
+    participant S2 as setup-project-fields.sh
+    participant S3 as setup-status-columns.sh
+    participant S4 as create-project-views.sh
+
+    User->>WF: workflow_dispatch（project_number）
+    Note over WF: extend-project ジョブ
+    Note over WF: ※ Project 作成ステップなし（既存 Project を使用）
+    WF->>RW: project_number を渡して呼び出し
+    RW->>S2: カスタムフィールドを作成
+    S2-->>RW: 完了
+    RW->>S3: ステータスカラムを設定
+    S3-->>RW: 完了
+    RW->>S4: View を作成
+    S4-->>RW: 完了
+    RW-->>WF: 完了
+```


### PR DESCRIPTION
## Summary
- `docs/01-create-project.md` に Mermaid シーケンス図を追加（ユーザー → ワークフロー → 各スクリプトの呼び出し順序を図示）
- `docs/02-extend-project.md` に Mermaid シーケンス図を追加（01 との違い：Project 作成ステップがスキップされる点を明確化）
- `docs/developers.md` の既存 Mermaid 図のスタイルに合わせて記述

close #40

## Test plan
- [ ] GitHub 上で `docs/01-create-project.md` のシーケンス図が正しくレンダリングされることを確認
- [ ] GitHub 上で `docs/02-extend-project.md` のシーケンス図が正しくレンダリングされることを確認
- [ ] 01 の図に Project 作成ステップが含まれていることを確認
- [ ] 02 の図に Project 作成ステップが含まれていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)