### PR TITLE
docs: ワークフロー 03/04 にフロー図・データフロー図（Mermaid）を追加 (#41)

### DIFF
--- a/docs/03-add-items-to-project.md
+++ b/docs/03-add-items-to-project.md
@@ -21,3 +21,45 @@
 | `item_label` | 絞り込みラベル（指定ラベルのみ追加） | - | `bug` |
 
 > **Note:** 既に Project に追加済みのアイテムは自動的にスキップされます。
+
+## 処理フロー
+
+```mermaid
+flowchart TD
+    A["workflow_dispatch"] --> B["パラメータ取得"]
+    B --> C{"include_issues?"}
+
+    C -- true --> D["Issue 一覧を取得"]
+    C -- false --> E{"include_prs?"}
+
+    D --> F{"item_label 指定あり?"}
+    F -- あり --> G["ラベルで絞り込み"]
+    F -- なし --> H["item_state で絞り込み"]
+    G --> H
+
+    H --> I["各 Issue をループ"]
+    I --> J{"Project に追加済み?"}
+    J -- Yes --> K["スキップ"]
+    J -- No --> L["Project に追加"]
+    K --> I
+    L --> I
+
+    I -- "完了" --> E
+
+    E -- true --> M["PR 一覧を取得"]
+    E -- false --> N["サマリー出力"]
+
+    M --> O{"item_label 指定あり?"}
+    O -- あり --> P["ラベルで絞り込み"]
+    O -- なし --> Q["item_state で絞り込み"]
+    P --> Q
+
+    Q --> R["各 PR をループ"]
+    R --> S{"Project に追加済み?"}
+    S -- Yes --> T["スキップ"]
+    S -- No --> U["Project に追加"]
+    T --> R
+    U --> R
+
+    R -- "完了" --> N
+```

--- a/docs/04-export-project-items.md
+++ b/docs/04-export-project-items.md
@@ -47,3 +47,25 @@
 
 - **GitHub Actions Summary:** 実行結果のサマリーとプレビューが表示されます
 - **artifact:** エクスポートファイルが artifact としてダウンロード可能です（保持期間: 30日）
+
+## 処理フロー
+
+```mermaid
+flowchart LR
+    A["workflow_dispatch"] --> B["パラメータ取得"]
+    B --> C["GraphQL API で\nProject アイテム取得"]
+    C --> D["ページネーション\n（100件ずつ）"]
+    D --> D
+    D --> E["アイテム一覧"]
+
+    E --> F{"output_format"}
+    F -- markdown --> G[".md"]
+    F -- csv --> H[".csv"]
+    F -- tsv --> I[".tsv"]
+    F -- json --> J[".json"]
+
+    G & H & I & J --> K["ファイル出力"]
+
+    K --> L["Actions Summary\nにプレビュー表示"]
+    K --> M["Artifact として\nアップロード"]
+```


### PR DESCRIPTION
## Summary
- `docs/03-add-items-to-project.md` に `flowchart TD` で分岐ロジック（Issue/PR 取得 → 既存チェック → スキップ or 追加）を図示
- `docs/04-export-project-items.md` に `flowchart LR` で GraphQL API → フォーマット変換 → 出力先分岐のデータフローを図示

## Test plan
- [ ] GitHub 上で 03-add-items-to-project.md の Mermaid 図が正しくレンダリングされることを確認
- [ ] GitHub 上で 04-export-project-items.md の Mermaid 図が正しくレンダリングされることを確認
- [ ] 図の内容がスクリプトの実際の処理フローと一致していることを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)