### PR TITLE
docs: ワークフロー処理フローのフローチャート方向とトンマナを統一

### DIFF
--- a/docs/workflows/01-create-project.md
+++ b/docs/workflows/01-create-project.md
@@ -22,5 +22,5 @@
 flowchart TD
     A["workflow_dispatch\n（タイトル・公開範囲）"] --> B["create-project ジョブ\nProject を新規作成し project_number を出力"]
     B --> C["extend-project ジョブ\nフィールド・ステータス・View を一括セットアップ"]
-    C --> D["完了"]
+    C --> D["完了\nproject_number を出力"]
 ```

--- a/docs/workflows/03-add-items-to-project.md
+++ b/docs/workflows/03-add-items-to-project.md
@@ -26,6 +26,6 @@
 
 ```mermaid
 flowchart TD
-    A["workflow_dispatch"] --> B["add-items ジョブ\nパラメータに基づき Issue/PR を取得し\nProject に一括追加（追加済みはスキップ）"]
+    A["workflow_dispatch\n（project_number・target_repo・フィルタ条件）"] --> B["add-items ジョブ\nパラメータに基づき Issue/PR を取得し\nProject に一括追加（追加済みはスキップ）"]
     B --> C["サマリー出力"]
 ```

--- a/docs/workflows/04-export-project-items.md
+++ b/docs/workflows/04-export-project-items.md
@@ -64,7 +64,7 @@
 ## 処理フロー
 
 ```mermaid
-flowchart LR
-    A["workflow_dispatch"] --> B["export-items ジョブ\nProject アイテムを取得し指定形式でエクスポート"]
+flowchart TD
+    A["workflow_dispatch\n（project_number・output_format）"] --> B["export-items ジョブ\nProject アイテムを取得し指定形式でエクスポート"]
     B --> C["Actions Summary に表示\n& Artifact アップロード"]
 ```


### PR DESCRIPTION
## Summary

- `04-export-project-items.md` のフローチャート方向を `flowchart LR` → `flowchart TD` に統一
- `03-add-items-to-project.md` と `04-export-project-items.md` の開始ノードにパラメータ概要を追加
- `01-create-project.md` の末尾ノードに `project_number` 出力のサマリを追加

## Test plan

- [ ] 各ドキュメントの Mermaid フローチャートが正しくレンダリングされることを確認
- [ ] 全フローチャートが `flowchart TD`（上から下）方向で統一されていることを確認
- [ ] 開始ノードにパラメータ概要が含まれていることを確認

close #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)