### PR TITLE
fix: export-project-items.sh の Step Summary データプレビューを削除

### DIFF
--- a/docs/scripts/export-project-items.md
+++ b/docs/scripts/export-project-items.md
@@ -30,8 +30,7 @@ flowchart TD
     G -- "json" --> K["JSON 形式\n（整形出力）"]
 
     H & I & J & K --> L["ファイルに出力\nexport-{number}-items.{ext}"]
-    L --> M["Step Summary 出力"]
-    M --> N["完了"]
+    L --> M["完了"]
 ```
 
 ## 処理詳細
@@ -44,7 +43,6 @@ flowchart TD
 | Markdown 出力 | Issue と PR を別セクションに分け、テーブル形式で出力。タイトル・ラベル・アサイン内の Markdown 特殊文字をエスケープ | `format_markdown` 関数 |
 | CSV / TSV 出力 | jq の `@csv` / `@tsv` フィルタで変換 | `format_csv` / `format_tsv` 関数 |
 | JSON 出力 | jq で整形して出力 | `format_json` 関数 |
-| Step Summary | Markdown の場合は 100 行まで埋め込み、その他は先頭 20 行をコードブロックでプレビュー表示 | — |
 
 ## API リファレンス
 

--- a/docs/workflows/04-export-project-items.md
+++ b/docs/workflows/04-export-project-items.md
@@ -60,7 +60,6 @@
 
 ## 出力先
 
-- **GitHub Actions Summary:** 実行結果のサマリーとプレビューが表示されます
 - **artifact:** エクスポートファイルが artifact としてダウンロード可能です（保持期間: 7日）
 
 ## 処理フロー
@@ -68,5 +67,5 @@
 ```mermaid
 flowchart TD
     A["workflow_dispatch\n（project_number・output_format）"] --> B["export-items ジョブ\nProject アイテムを取得し指定形式でエクスポート"]
-    B --> C["Actions Summary に表示\n& Artifact アップロード"]
+    B --> C["Artifact アップロード"]
 ```

--- a/scripts/export-project-items.sh
+++ b/scripts/export-project-items.sh
@@ -256,46 +256,6 @@ esac
 
 echo "ファイル出力: ${OUTPUT_FILE}"
 
-# --- Step Summary ---
-
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "## Project アイテム エクスポート 完了"
-    echo ""
-    echo "| 項目 | 値 |"
-    echo "|------|-----|"
-    echo "| Project Owner | \`${PROJECT_OWNER}\` |"
-    echo "| Project Number | ${PROJECT_NUMBER} |"
-    echo "| Project Title | ${PROJECT_TITLE} |"
-    echo "| 出力形式 | ${OUTPUT_FORMAT} |"
-    echo "| Issue 件数 | ${ISSUE_COUNT} 件 |"
-    echo "| PR 件数 | ${PR_COUNT} 件 |"
-    echo "| **合計** | **${TOTAL_COUNT} 件** |"
-    echo ""
-
-    if [[ "${OUTPUT_FORMAT}" == "markdown" ]]; then
-      # markdown はそのまま埋め込み（100行まで）
-      line_count=$(wc -l < "${OUTPUT_FILE}" | tr -d ' ')
-      if [[ "${line_count}" -le 100 ]]; then
-        cat "${OUTPUT_FILE}"
-      else
-        head -100 "${OUTPUT_FILE}"
-        echo ""
-        echo "> ... 以降省略（全 ${line_count} 行）。完全なデータは artifact からダウンロードしてください。"
-      fi
-    else
-      # csv/tsv/json はコードブロックでプレビュー
-      echo "### プレビュー（先頭20行）"
-      echo ""
-      echo '```'
-      head -20 "${OUTPUT_FILE}"
-      echo '```'
-      echo ""
-      echo "> 完全なデータは artifact からダウンロードしてください。"
-    fi
-  } >> "${GITHUB_STEP_SUMMARY}"
-fi
-
 # --- コンソールサマリー ---
 
 print_summary "Project" "${PROJECT_TITLE} (#${PROJECT_NUMBER})" \


### PR DESCRIPTION
## Summary

- `scripts/export-project-items.sh` から `GITHUB_STEP_SUMMARY` へのデータプレビュー出力（Step Summary セクション全体）を削除
- `docs/scripts/export-project-items.md` の処理フロー図・処理詳細テーブルから Step Summary 関連の記述を除去
- `docs/workflows/04-export-project-items.md` の出力先・処理フロー図から Actions Summary 関連の記述を除去

closes #65

## Test plan

- [ ] ワークフロー実行後、artifact にエクスポートファイルが出力されることを確認
- [ ] コンソールサマリー（`print_summary`）は従来通り表示されることを確認
- [ ] Step Summary にデータプレビューが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)