### PR TITLE
fix: project_number の input タイプを string から number に変更

### DIFF
--- a/.github/workflows/02-extend-project.yml
+++ b/.github/workflows/02-extend-project.yml
@@ -6,7 +6,7 @@ on:
       project_number:
         description: "対象 Project の Number"
         required: true
-        type: string
+        type: number
 
 permissions:
   contents: read

--- a/.github/workflows/03-add-items-to-project.yml
+++ b/.github/workflows/03-add-items-to-project.yml
@@ -6,7 +6,7 @@ on:
       project_number:
         description: "対象 Project の Number"
         required: true
-        type: string
+        type: number
       target_repo:
         description: "対象リポジトリ（owner/repo 形式、1回の実行で1リポジトリ）"
         required: true

--- a/.github/workflows/04-export-project-items.yml
+++ b/.github/workflows/04-export-project-items.yml
@@ -6,7 +6,7 @@ on:
       project_number:
         description: "対象 Project の Number"
         required: true
-        type: string
+        type: number
       output_format:
         description: "出力形式"
         required: true

--- a/.github/workflows/_reusable-extend-project.yml
+++ b/.github/workflows/_reusable-extend-project.yml
@@ -6,7 +6,7 @@ on:
       project_number:
         description: "対象 Project の Number"
         required: true
-        type: string
+        type: number
     secrets:
       PROJECT_PAT:
         description: "GitHub PAT（Projects 操作権限が必要）"

--- a/docs/workflows/02-extend-project.md
+++ b/docs/workflows/02-extend-project.md
@@ -14,7 +14,7 @@
 
 | パラメータ | 説明 | 必須 | タイプ | 例 |
 |------------|------|:----:|--------|-----|
-| `project_number` | 対象 Project の Number | ✅ | `string` | `1` |
+| `project_number` | 対象 Project の Number | ✅ | `number` | `1` |
 
 ## 処理フロー
 

--- a/docs/workflows/03-add-items-to-project.md
+++ b/docs/workflows/03-add-items-to-project.md
@@ -13,7 +13,7 @@
 
 | パラメータ | 説明 | 必須 | タイプ | 例 |
 |------------|------|:----:|--------|-----|
-| `project_number` | 対象 Project の Number | ✅ | `string` | `1` |
+| `project_number` | 対象 Project の Number | ✅ | `number` | `1` |
 | `target_repo` | 対象リポジトリ（owner/repo 形式） | ✅ | `string` | `myorg/myrepo` |
 | `include_issues` | Issue を追加対象にする | ✅ | `boolean` | `true`（デフォルト） |
 | `include_prs` | Pull Request を追加対象にする | ✅ | `boolean` | `true`（デフォルト） |

--- a/docs/workflows/04-export-project-items.md
+++ b/docs/workflows/04-export-project-items.md
@@ -13,7 +13,7 @@
 
 | パラメータ | 説明 | 必須 | タイプ | 例 |
 |------------|------|:----:|--------|-----|
-| `project_number` | 対象 Project の Number | ✅ | `string` | `1` |
+| `project_number` | 対象 Project の Number | ✅ | `number` | `1` |
 | `output_format` | 出力形式 | ✅ | `choice` | `markdown`（デフォルト） |
 | `include_issues` | Issue を対象にする | ✅ | `boolean` | `true`（デフォルト） |
 | `include_prs` | Pull Request を対象にする | ✅ | `boolean` | `true`（デフォルト） |


### PR DESCRIPTION
## Summary
- ワークフロー定義4ファイルの `project_number` パラメータの `type` を `string` → `number` に変更
- 対応するドキュメント3ファイルのタイプ列を `string` → `number` に更新

## Why
`project_number` は GitHub Project の番号であり常に正の整数のため、`type: number` にすることで GitHub Actions UI 側での数値バリデーションが有効になる。

closes #75

## Test plan
- [ ] GitHub Actions の `Run workflow` UI で `project_number` に数値入力フィールドが表示されることを確認
- [ ] 各ワークフローが正常に実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)