### PR TITLE
refactor: スクリプトファイル名を setup-* 命名規則に統一

### DIFF
--- a/.github/workflows/_reusable-extend-project.yml
+++ b/.github/workflows/_reusable-extend-project.yml
@@ -32,10 +32,10 @@ jobs:
 
       - name: ステータスカラムを設定
         run: |
-          chmod +x scripts/setup-status-columns.sh
-          bash scripts/setup-status-columns.sh
+          chmod +x scripts/setup-project-status.sh
+          bash scripts/setup-project-status.sh
 
       - name: View を作成
         run: |
-          chmod +x scripts/create-project-views.sh
-          bash scripts/create-project-views.sh
+          chmod +x scripts/setup-project-views.sh
+          bash scripts/setup-project-views.sh

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -16,8 +16,8 @@ flowchart TD
     subgraph scripts ["スクリプト層"]
         S1["setup-github-project.sh"]
         S2["setup-project-fields.sh"]
-        S3["setup-status-columns.sh"]
-        S4["create-project-views.sh"]
+        S3["setup-project-status.sh"]
+        S4["setup-project-views.sh"]
         S5["add-items-to-project.sh"]
         S6["export-project-items.sh"]
         SL["lib/common.sh"]
@@ -50,8 +50,8 @@ scripts/
   │   └── common.sh                # 共通関数ライブラリ
   ├── setup-github-project.sh      # Project 作成スクリプト
   ├── setup-project-fields.sh      # カスタムフィールド作成スクリプト
-  ├── setup-status-columns.sh      # ステータスカラム設定スクリプト
-  ├── create-project-views.sh      # View 作成スクリプト
+  ├── setup-project-status.sh      # ステータスカラム設定スクリプト
+  ├── setup-project-views.sh      # View 作成スクリプト
   ├── add-items-to-project.sh      # アイテム一括追加スクリプト
   └── export-project-items.sh      # アイテムエクスポートスクリプト
 ```
@@ -66,8 +66,8 @@ scripts/
   │   └── scripts/setup-github-project.sh   # Project 作成
   └── extend-project ジョブ（_reusable-extend-project.yml）
       ├── scripts/setup-project-fields.sh    # カスタムフィールド作成
-      ├── scripts/setup-status-columns.sh    # ステータスカラム設定
-      └── scripts/create-project-views.sh    # View 作成
+      ├── scripts/setup-project-status.sh    # ステータスカラム設定
+      └── scripts/setup-project-views.sh    # View 作成
 ```
 
 ### ② GitHub Project 拡張
@@ -76,8 +76,8 @@ scripts/
 02-extend-project.yml
   └── extend-project ジョブ（_reusable-extend-project.yml）
       ├── scripts/setup-project-fields.sh    # カスタムフィールド作成
-      ├── scripts/setup-status-columns.sh    # ステータスカラム設定
-      └── scripts/create-project-views.sh    # View 作成
+      ├── scripts/setup-project-status.sh    # ステータスカラム設定
+      └── scripts/setup-project-views.sh    # View 作成
 ```
 
 ### ③ Issue/PR 一括紐付け
@@ -103,7 +103,7 @@ scripts/
 |-----------|------|
 | [setup-github-project.sh](scripts/setup-github-project) | Owner 種別を自動判定し、Project を新規作成する |
 | [setup-project-fields.sh](scripts/setup-project-fields) | Priority・Estimate・Category・Due Date のカスタムフィールドを作成する |
-| [setup-status-columns.sh](scripts/setup-status-columns) | Todo・In Progress・Done のステータスカラムを設定する |
-| [create-project-views.sh](scripts/create-project-views) | Table・Board・Roadmap の 3 種類の View を作成する |
+| [setup-project-status.sh](scripts/setup-project-status) | Todo・In Progress・Done のステータスカラムを設定する |
+| [setup-project-views.sh](scripts/setup-project-views) | Table・Board・Roadmap の 3 種類の View を作成する |
 | [add-items-to-project.sh](scripts/add-items-to-project) | 指定リポジトリの Issue/PR を Project に一括追加する。追加済みアイテムは自動スキップ |
 | [export-project-items.sh](scripts/export-project-items) | 指定 Project の Issue/PR 一覧を取得し、指定形式でエクスポートする |

--- a/docs/scripts/setup-project-status.md
+++ b/docs/scripts/setup-project-status.md
@@ -1,4 +1,4 @@
-# setup-status-columns.sh
+# setup-project-status.sh
 
 Project の Status フィールドにカラムを設定するスクリプトです。
 既存の Status フィールドに対して、定義済みのカラムを追加・更新します。
@@ -37,7 +37,7 @@ graph LR
 
 ```mermaid
 sequenceDiagram
-    participant Script as setup-status-columns.sh
+    participant Script as setup-project-status.sh
     participant FS as ファイルシステム
     participant GH as GitHub GraphQL API
 

--- a/docs/scripts/setup-project-views.md
+++ b/docs/scripts/setup-project-views.md
@@ -1,4 +1,4 @@
-# create-project-views.sh
+# setup-project-views.sh
 
 Project に View を自動作成するスクリプトです。
 既に同名の View が存在する場合は自動的にスキップされます。

--- a/scripts/setup-project-status.sh
+++ b/scripts/setup-project-status.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # GitHub Project ステータスカラム設定スクリプト
-# https://mabubu0203.github.io/github-projects-starter-kit/scripts/setup-status-columns
+# https://mabubu0203.github.io/github-projects-starter-kit/scripts/setup-project-status
 #
 # 環境変数:
 #   GH_TOKEN       - GitHub PAT（Projects 操作権限が必要）

--- a/scripts/setup-project-views.sh
+++ b/scripts/setup-project-views.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # GitHub Project View 作成スクリプト
-# https://mabubu0203.github.io/github-projects-starter-kit/scripts/create-project-views
+# https://mabubu0203.github.io/github-projects-starter-kit/scripts/setup-project-views
 #
 # 環境変数:
 #   GH_TOKEN          - GitHub PAT（Projects 操作権限が必要）


### PR DESCRIPTION
## Summary
- `create-project-views.sh` → `setup-project-views.sh` にリネーム
- `setup-status-columns.sh` → `setup-project-status.sh` にリネーム
- ドキュメント（`docs/scripts/`、`docs/developers.md`）の参照箇所を更新
- ワークフロー（`_reusable-extend-project.yml`）のスクリプト呼び出しを更新

## Test plan
- [ ] ワークフロー `_reusable-extend-project.yml` 内のスクリプトパスが正しいことを確認
- [ ] ドキュメントサイトのリンクが正しく動作することを確認
- [ ] `docs/developers.md` の mermaid 図・構成ファイル一覧が正しいことを確認

closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)