### PR TITLE
enhance: gh project edit に --format json を追加し結果を検証する

### DIFF
--- a/docs/scripts/setup-github-project.md
+++ b/docs/scripts/setup-github-project.md
@@ -35,7 +35,10 @@ flowchart TD
     N -- "No" --> O["エラー出力\n手動設定コマンド表示"]
     O --> K
 
-    N -- "Yes" --> P["GITHUB_OUTPUT に\nproject_number / url 出力"]
+    N -- "Yes" --> S{"Visibility 検証"}
+    S -- "不一致" --> T["警告出力"]
+    S -- "一致" --> U["検証成功通知"]
+    T & U --> P["GITHUB_OUTPUT に\nproject_number / url 出力"]
     P --> Q["Step Summary 出力"]
     Q --> R["完了"]
 ```
@@ -48,7 +51,8 @@ flowchart TD
 | オーナータイプ判定 | GitHub REST API でオーナーの `.type` を取得し、User / Organization を判別 | `gh api users/{owner} --jq '.type'` |
 | Project 作成 | GitHub CLI の Project 作成コマンドを実行 | `gh project create --title --owner --format json` |
 | 情報抽出 | 作成結果の JSON から `number` と `url` を取得 | `jq -r '.number'`・`jq -r '.url'` |
-| Visibility 設定 | 作成した Project の公開範囲を指定値に変更 | `gh project edit {number} --owner --visibility` |
+| Visibility 設定 | 作成した Project の公開範囲を指定値に変更 | `gh project edit {number} --owner --visibility --format json` |
+| Visibility 検証 | レスポンス JSON の `visibility` が期待値と一致するか確認 | `jq -r '.visibility'` |
 | サマリー出力 | `GITHUB_OUTPUT` へ後続ステップ連携用の値を設定、`GITHUB_STEP_SUMMARY` にテーブル出力 | — |
 
 ## API リファレンス

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -93,7 +93,7 @@ fi
 echo ""
 echo "Visibility を ${PROJECT_VISIBILITY} に設定します..."
 
-if ! EDIT_OUTPUT=$(gh project edit "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" --visibility "${PROJECT_VISIBILITY}" 2>&1); then
+if ! EDIT_OUTPUT=$(gh project edit "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" --visibility "${PROJECT_VISIBILITY}" --format json 2>&1); then
   SAFE_EDIT_OUTPUT=$(sanitize_for_workflow_command "${EDIT_OUTPUT}")
   echo "::error::Visibility の設定に失敗しました: ${SAFE_EDIT_OUTPUT}"
   echo "::error::Project は作成されましたが、Visibility はデフォルト（PRIVATE）のままです。"
@@ -101,7 +101,16 @@ if ! EDIT_OUTPUT=$(gh project edit "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}
   exit 1
 fi
 
-echo "::notice::Visibility を ${PROJECT_VISIBILITY} に設定しました。"
+# Visibility 設定結果の検証
+ACTUAL_VISIBILITY=$(echo "${EDIT_OUTPUT}" | jq -r '.visibility // empty')
+
+if [[ -z "${ACTUAL_VISIBILITY}" ]]; then
+  echo "::warning::Visibility の検証をスキップしました（レスポンスから visibility を取得できませんでした）。"
+elif [[ "${ACTUAL_VISIBILITY}" != "${PROJECT_VISIBILITY}" ]]; then
+  echo "::warning::Visibility の設定値が期待と異なります。期待: ${PROJECT_VISIBILITY}、実際: ${ACTUAL_VISIBILITY}"
+else
+  echo "::notice::Visibility を ${PROJECT_VISIBILITY} に設定し、検証に成功しました。"
+fi
 
 # --- サマリー出力 ---
 


### PR DESCRIPTION
## Summary
- `gh project edit` コマンドに `--format json` を追加し、Visibility 設定結果を JSON で取得
- レスポンスの `visibility` を期待値と照合する検証ロジックを追加
- ドキュメント（フローチャート・処理詳細テーブル）を更新

## Test plan
- [ ] `PROJECT_VISIBILITY=PUBLIC` で実行し、検証成功のnoticeが出力されることを確認
- [ ] `PROJECT_VISIBILITY=PRIVATE` で実行し、検証成功のnoticeが出力されることを確認
- [ ] スクリプトの構文チェック（`bash -n`）がパスすることを確認

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)