### PR TITLE
refactor: カンバンフロー図をQ&Aセクションに移動する

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,3 +67,24 @@ gh issue list -R owner/repo
 # Pull Request 一覧
 gh pr list -R owner/repo
 ```
+
+---
+
+## Q4. カンバンのフローはどうなっていますか？
+
+```mermaid
+graph LR
+    Backlog["⚪ Backlog\n(GRAY)"]
+    Todo["🔵 Todo\n(BLUE)"]
+    InProgress["🟡 In Progress\n(YELLOW)"]
+    InReview["🟠 In Review\n(ORANGE)"]
+    Done["🟢 Done\n(GREEN)"]
+
+    Backlog --> Todo --> InProgress --> InReview --> Done
+    InReview -- "差し戻し" --> InProgress
+```
+
+### 手戻り時の運用ルール
+
+- **レビュー差し戻し**: In Review → In Progress に戻す
+- **Done後のバグ発覚**: 同Issueを戻さず、新しいバグIssueを起票する

--- a/docs/scripts/setup-project-status.md
+++ b/docs/scripts/setup-project-status.md
@@ -68,27 +68,6 @@ flowchart TD
 |-----------|---------|------|
 | `fields(first: N)` | 50 | Status フィールド検索用（ビルトイン＋カスタムフィールドを取得） |
 
-## Q&A
-
-### カンバンのフローはどうなっていますか？
-
-```mermaid
-graph LR
-    Backlog["⚪ Backlog\n(GRAY)"]
-    Todo["🔵 Todo\n(BLUE)"]
-    InProgress["🟡 In Progress\n(YELLOW)"]
-    InReview["🟠 In Review\n(ORANGE)"]
-    Done["🟢 Done\n(GREEN)"]
-
-    Backlog --> Todo --> InProgress --> InReview --> Done
-    InReview -- "差し戻し" --> InProgress
-```
-
-### 手戻り時はどう運用しますか？
-
-- **レビュー差し戻し**: In Review → In Progress に戻す
-- **Done後のバグ発覚**: 同Issueを戻さず、新しいバグIssueを起票する
-
 ## 使用ワークフロー
 
 - [① GitHub Project 新規作成](../workflows/01-create-project)


### PR DESCRIPTION
## Summary
- `docs/scripts/setup-project-status.md` のカンバンフロー図と手戻り時の運用ルールをQ&Aセクションに移動
- スクリプトの処理仕様と運用上の参考情報を分離し、ドキュメント構成を整理

## Test plan
- [ ] Q&Aセクションにカンバンフロー図（mermaid）が正しく表示されること
- [ ] Q&Aセクションに手戻り時の運用ルールが記載されていること
- [ ] 処理フローや処理詳細セクションに影響がないこと

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)