### PR TITLE
fix: Project 作成を GraphQL createProjectV2 に置き換える

### DIFF
--- a/docs/scripts/setup-github-project.md
+++ b/docs/scripts/setup-github-project.md
@@ -29,13 +29,13 @@ flowchart TD
     I -- "Yes" --> J["警告出力\n重複防止で正常終了"]
     I -- "No" --> K["GraphQL createProjectV2\nで Project 作成"]
     K --> L{"作成成功?"}
-    L -- "No" --> M["エラー出力\n原因候補を表示"]
+    L -- "No" --> M["GraphQL エラー内容を\n出力"]
     M --> N["異常終了"]
 
     L -- "Yes" --> O["project_number / url を抽出"]
     O --> P["GraphQL updateProjectV2\nで Visibility 設定"]
     P --> Q{"設定成功?"}
-    Q -- "No" --> R["エラー出力\n手動設定コマンド表示"]
+    Q -- "No" --> R["GraphQL エラー内容を\n出力"]
     R --> N
 
     Q -- "Yes" --> S{"Visibility 検証"}
@@ -54,7 +54,7 @@ flowchart TD
 | オーナータイプ判定 | GitHub REST API でオーナーの `.type` と `.node_id` を取得し、User / Organization を判別 | `gh api users/{owner} --jq '{type, node_id}'` |
 | 重複チェック | 同一 Owner 配下に同名タイトルの Project が存在するか確認し、存在する場合は警告を出して正常終了（ページネーションで全件走査） | GraphQL `projectsV2(first: 100)` + `pageInfo`・`jq 'select(.title == ...)'` |
 | Project 作成 | GraphQL mutation で Project を作成 | GraphQL `createProjectV2(input: {ownerId, title})` |
-| 情報抽出 | 作成結果の JSON から `number` と `url` を取得 | `jq -r '.number'`・`jq -r '.url'` |
+| 情報抽出 | 作成結果の JSON から `id`・`number`・`url` を取得 | `jq -c '.data.createProjectV2.projectV2'` + `jq -r '@tsv'` |
 | Visibility 設定 | 作成した Project の公開範囲を指定値に変更 | GraphQL `updateProjectV2(input: {projectId, public})` |
 | Visibility 検証 | レスポンス JSON の `public` が期待値と一致するか確認 | `jq '.public'` |
 | サマリー出力 | `GITHUB_OUTPUT` へ後続ステップ連携用の値を設定、`GITHUB_STEP_SUMMARY` にテーブル出力 | — |

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -71,8 +71,13 @@ detect_owner_type() {
     exit 1
   fi
 
-  OWNER_TYPE=$(echo "${owner_json}" | jq -r '.type')
-  OWNER_NODE_ID=$(echo "${owner_json}" | jq -r '.node_id')
+  IFS=$'\t' read -r OWNER_TYPE OWNER_NODE_ID < <(echo "${owner_json}" | jq -r '[.type, .node_id] | @tsv')
+
+  if [[ -z "${OWNER_NODE_ID}" || "${OWNER_NODE_ID}" == "null" ]]; then
+    echo "::error::オーナーの node_id を取得できませんでした。PAT の権限を確認してください。"
+    exit 1
+  fi
+
   echo "  オーナータイプ: ${OWNER_TYPE}"
 
   if [[ "${OWNER_TYPE}" == "User" ]]; then

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -109,22 +109,28 @@ CREATE_MUTATION='mutation($ownerId: ID!, $title: String!) {
 }'
 OUTPUT=$(run_graphql "${CREATE_MUTATION}" "GitHub Project の作成" -f ownerId="${OWNER_NODE_ID}" -f title="${PROJECT_TITLE}")
 
-echo "::notice::GitHub Project の作成に成功しました。"
-echo "${OUTPUT}" | jq '.data.createProjectV2.projectV2' 2>/dev/null || echo "${OUTPUT}"
-
 # --- Project 情報の抽出 ---
 
-PROJECT_ID=$(echo "${OUTPUT}" | jq -r '.data.createProjectV2.projectV2.id // empty')
-PROJECT_NUMBER=$(echo "${OUTPUT}" | jq -r '.data.createProjectV2.projectV2.number // empty')
-PROJECT_URL=$(echo "${OUTPUT}" | jq -r '.data.createProjectV2.projectV2.url // empty')
+PROJECT_V2=$(echo "${OUTPUT}" | jq -c '.data.createProjectV2.projectV2 // empty' 2>/dev/null)
 
-if [[ -z "${PROJECT_NUMBER}" ]]; then
-  echo "::error::Project Number を抽出できませんでした。GraphQL レスポンスを確認してください。"
-  OUTPUT_HEAD=$(echo "${OUTPUT}" | head -5)
-  SAFE_OUTPUT_HEAD=$(sanitize_for_workflow_command "${OUTPUT_HEAD}")
-  echo "::error::出力: ${SAFE_OUTPUT_HEAD}"
+if [[ -z "${PROJECT_V2}" || "${PROJECT_V2}" == "null" ]]; then
+  echo "::error::Project 情報を抽出できませんでした。GraphQL レスポンスを確認してください。"
+  SAFE_OUTPUT=$(sanitize_for_workflow_command "$(echo "${OUTPUT}" | head -5)")
+  echo "::error::出力: ${SAFE_OUTPUT}"
   exit 1
 fi
+
+IFS=$'\t' read -r PROJECT_ID PROJECT_NUMBER PROJECT_URL < <(echo "${PROJECT_V2}" | jq -r '[.id, .number, .url] | @tsv')
+
+if [[ -z "${PROJECT_ID}" || -z "${PROJECT_NUMBER}" ]]; then
+  echo "::error::Project ID または Number を抽出できませんでした。GraphQL レスポンスを確認してください。"
+  SAFE_OUTPUT=$(sanitize_for_workflow_command "$(echo "${OUTPUT}" | head -5)")
+  echo "::error::出力: ${SAFE_OUTPUT}"
+  exit 1
+fi
+
+echo "::notice::GitHub Project の作成に成功しました。"
+echo "${PROJECT_V2}" | jq '.' 2>/dev/null || echo "${PROJECT_V2}"
 
 # --- Visibility 設定 ---
 


### PR DESCRIPTION
## Summary

- `gh project create` コマンドが `unknown owner type` エラーで失敗する問題を修正
- `detect_owner_type` 関数でオーナーの `node_id` も取得するよう拡張
- Project 作成を GraphQL `createProjectV2` mutation に置き換え、`gh project create` への依存を排除

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `scripts/lib/common.sh` | `detect_owner_type` で `OWNER_NODE_ID` も取得 |
| `scripts/setup-github-project.sh` | `gh project create` → `createProjectV2` mutation |
| `docs/scripts/setup-github-project.md` | 処理フロー図・テーブル・API リファレンスを更新 |

## Test plan

- [ ] ワークフロー「① GitHub Project 新規作成」を User オーナーで実行し、Project が作成されることを確認
- [ ] Organization オーナーでも同様に動作することを確認
- [ ] 重複チェック（既存 Project がある場合）が引き続き正常に動作することを確認

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)