### PR TITLE
fix: fields(first: 250) を GraphQL API 上限の 100 に修正する

### DIFF
--- a/docs/scripts/setup-project-fields.md
+++ b/docs/scripts/setup-project-fields.md
@@ -83,7 +83,7 @@ flowchart TD
 |---------|---------|-------------------|
 | オーナータイプ判定 | `detect_owner_type` で Organization / User を判別し、GraphQL クエリのフィールド名を決定 | `gh api users/{owner}` |
 | フィールド定義ファイル読み込み | `scripts/config/field-definitions.json` からフィールド定義を読み込み | `cat` |
-| 既存フィールド取得 | GraphQL クエリで Project ID と全フィールド（名前・データ型・選択肢）を一括取得 | `gh api graphql` — `projectV2.fields(first: 250)` |
+| 既存フィールド取得 | GraphQL クエリで Project ID と全フィールド（名前・データ型・選択肢）を一括取得 | `gh api graphql` — `projectV2.fields(first: 100)` |
 | 重複チェック | 既存フィールド名リストと定義済みフィールド名を `grep -Fqx` で完全一致比較 | — |
 | フィールド作成 | `SINGLE_SELECT` の場合は `--single-select-options` で選択肢を付与して作成 | `gh project field-create {number} --owner --name --data-type` |
 | サマリー出力 | 作成・スキップ・失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | — |
@@ -99,7 +99,7 @@ flowchart TD
 
 | パラメータ | 現在の値 | 備考 |
 |-----------|---------|------|
-| `fields(first: N)` | 250 | Project のフィールド数上限に合わせた値 |
+| `fields(first: N)` | 100 | GitHub GraphQL API の `first` パラメータ上限 |
 
 ## 使用ワークフロー
 

--- a/scripts/setup-project-fields.sh
+++ b/scripts/setup-project-fields.sh
@@ -37,7 +37,7 @@ query {
   ${OWNER_QUERY_FIELD}(login: "${PROJECT_OWNER}") {
     projectV2(number: ${PROJECT_NUMBER}) {
       id
-      fields(first: 250) {
+      fields(first: 100) {
         nodes {
           ... on ProjectV2Field {
             id


### PR DESCRIPTION
## Summary
- `scripts/setup-project-fields.sh` の `fields(first: 250)` を `fields(first: 100)` に変更し、`EXCESSIVE_PAGINATION` エラーを修正
- `docs/scripts/setup-project-fields.md` のドキュメントも同様に更新

Closes #110

## Test plan
- [ ] `setup-project-fields.sh` を実行し、`EXCESSIVE_PAGINATION` エラーが発生しないことを確認
- [ ] 既存フィールドの取得が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)