### PR TITLE
fix: updateProjectV2Field の singleSelectOptions を GraphQL 変数方式に変更する

### DIFF
--- a/scripts/setup-project-status.sh
+++ b/scripts/setup-project-status.sh
@@ -96,12 +96,12 @@ echo "${STATUS_OPTIONS}" | jq -r '.[] | "  - \(.name) (\(.color))\(if .descripti
 # GraphQL mutation 用の singleSelectOptions を構築
 SINGLE_SELECT_OPTIONS=$(echo "${STATUS_OPTIONS}" | jq -c '[.[] | {name: .name, color: .color, description: (.description // "")}]')
 
-UPDATE_MUTATION=$(cat <<GRAPHQL
-mutation {
+UPDATE_MUTATION=$(cat <<'GRAPHQL'
+mutation($projectId: ID!, $fieldId: ID!, $singleSelectOptions: [ProjectV2SingleSelectFieldOptionInput!]!) {
   updateProjectV2Field(input: {
-    projectId: "${PROJECT_ID}"
-    fieldId: "${STATUS_FIELD_ID}"
-    singleSelectOptions: ${SINGLE_SELECT_OPTIONS}
+    projectId: $projectId
+    fieldId: $fieldId
+    singleSelectOptions: $singleSelectOptions
   }) {
     projectV2Field {
       ... on ProjectV2SingleSelectField {
@@ -120,7 +120,10 @@ mutation {
 GRAPHQL
 )
 
-UPDATE_RESULT=$(run_graphql "${UPDATE_MUTATION}" "ステータスカラムの更新")
+UPDATE_RESULT=$(run_graphql "${UPDATE_MUTATION}" "ステータスカラムの更新" \
+  -f "projectId=${PROJECT_ID}" \
+  -f "fieldId=${STATUS_FIELD_ID}" \
+  -F "singleSelectOptions=${SINGLE_SELECT_OPTIONS}")
 
 echo ""
 echo "::notice::ステータスカラムの更新に成功しました。"


### PR DESCRIPTION
## Summary
- `scripts/setup-project-status.sh` の `updateProjectV2Field` mutation で、JSON キーがクォート付きのまま GraphQL に展開され `Expected NAME, actual: STRING` エラーになっていた問題を修正
- GraphQL 変数（`$projectId`, `$fieldId`, `$singleSelectOptions`）方式に変更し、`run_graphql` の追加引数で `-f` / `-F` フラグを使って渡す方式に変更

Closes #111

## Test plan
- [ ] `setup-project-status.sh` を実行し、GraphQL 構文エラーが発生しないことを確認
- [ ] ステータスカラムが正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)