### PR TITLE
fix: updateProjectV2Field mutation から projectId を削除する

### DIFF
--- a/scripts/setup-project-status.sh
+++ b/scripts/setup-project-status.sh
@@ -97,9 +97,8 @@ echo "${STATUS_OPTIONS}" | jq -r '.[] | "  - \(.name) (\(.color))\(if .descripti
 SINGLE_SELECT_OPTIONS=$(echo "${STATUS_OPTIONS}" | jq -c '[.[] | {name: .name, color: .color, description: (.description // "")}]')
 
 UPDATE_MUTATION=$(cat <<'GRAPHQL'
-mutation($projectId: ID!, $fieldId: ID!, $singleSelectOptions: [ProjectV2SingleSelectFieldOptionInput!]!) {
+mutation($fieldId: ID!, $singleSelectOptions: [ProjectV2SingleSelectFieldOptionInput!]!) {
   updateProjectV2Field(input: {
-    projectId: $projectId
     fieldId: $fieldId
     singleSelectOptions: $singleSelectOptions
   }) {
@@ -121,7 +120,6 @@ GRAPHQL
 )
 
 UPDATE_RESULT=$(run_graphql "${UPDATE_MUTATION}" "ステータスカラムの更新" \
-  -f "projectId=${PROJECT_ID}" \
   -f "fieldId=${STATUS_FIELD_ID}" \
   -F "singleSelectOptions=${SINGLE_SELECT_OPTIONS}")
 


### PR DESCRIPTION
## Summary
- GitHub GraphQL API の破壊的変更により `UpdateProjectV2FieldInput` から `projectId` が削除された
- `setup-project-status.sh` の mutation 定義と `run_graphql` 呼び出しから `projectId` を除去
- `fieldId` のみでステータスカラムの更新が正常に完了するようにした

## Test plan
- [ ] `setup-project-status.sh` を実行してステータスカラムの更新が成功すること
- [ ] 更新後のステータスカラムが正しく表示されること

closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)