### PR TITLE
docs: 画像を <details><summary> で折りたたみ可能にする

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,9 +15,14 @@ GitHub Project の URL 末尾の数字が `project_number` です。
 
 **例:** `https://github.com/users/octocat/projects/3` → `project_number` は **3**
 
+<details>
+<summary>スクリーンショットを表示</summary>
+
 > **参考画像:** Organization の Projects 一覧画面では、各プロジェクト名の下に `#番号` が表示されます。
 >
 > <img src="images/faq-project-number.png" alt="project_number の確認例" width="50%">
+
+</details>
 
 ### CLI で確認する方法
 
@@ -35,9 +40,14 @@ gh project list
 
 **例:** `https://github.com/octocat/my-app` → `target_repo` は **octocat/my-app**
 
+<details>
+<summary>スクリーンショットを表示</summary>
+
 > **参考画像:** リポジトリページのヘッダーに `owner/repo` 形式で表示されています。
 >
 > <img src="images/faq-target-repo.png" alt="target_repo の確認例" width="50%">
+
+</details>
 
 ### CLI で確認する方法
 

--- a/docs/quickstart-gui.md
+++ b/docs/quickstart-gui.md
@@ -16,19 +16,29 @@ flowchart LR
 
 リポジトリページ右上の「Fork」ボタンをクリックします。
 
+<details>
+<summary>スクリーンショットを表示</summary>
+
 > **参考画像:** リポジトリページ右上に「Fork」ボタンが表示されています。
 >
 > <img src="images/quickstart-fork-button.png" alt="Fork ボタンの位置" width="30%">
 >
 > <img src="images/quickstart-fork-page.png" alt="Fork ボタンが表示されたリポジトリページ" width="80%">
 
+</details>
+
 ## 2. PAT を作成する
 
 GitHub の [Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens) から PAT を作成します。
 
+<details>
+<summary>スクリーンショットを表示</summary>
+
 > **参考画像:** Settings > Developer settings > Personal access tokens 画面
 >
 > <img src="images/quickstart-pat.png" alt="PAT 作成画面" width="80%">
+
+</details>
 
 必要な権限の詳細は [FAQ > Q5. PAT にはどの権限が必要ですか？](faq#q5-pat-にはどの権限が必要ですか) を参照してください。Fine-grained token の制約事項については [Q7](faq#q7-fine-grained-token-の制約事項はありますか) も合わせてご確認ください。
 


### PR DESCRIPTION
## Summary
- `docs/quickstart-gui.md` の画像3枚と `docs/faq.md` の画像2枚を `<details><summary>` タグで囲み、折りたたみ可能にした
- ページのスクロール量を軽減し、閲覧時の負担を減らす

closes #138

## Test plan
- [ ] `docs/quickstart-gui.md` の画像3箇所が折りたたみ表示されることを確認
- [ ] `docs/faq.md` の画像2箇所が折りたたみ表示されることを確認
- [ ] 折りたたみを展開して画像が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)