### PR TITLE
docs: <details><summary> の文言を具体的な内容に変更

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ GitHub Project の URL 末尾の数字が `project_number` です。
 **例:** `https://github.com/users/octocat/projects/3` → `project_number` は **3**
 
 <details>
-<summary>スクリーンショットを表示</summary>
+<summary><code>project_number</code> の確認例（スクリーンショット）を表示</summary>
 
 > **参考画像:** Organization の Projects 一覧画面では、各プロジェクト名の下に `#番号` が表示されます。
 >
@@ -41,7 +41,7 @@ gh project list
 **例:** `https://github.com/octocat/my-app` → `target_repo` は **octocat/my-app**
 
 <details>
-<summary>スクリーンショットを表示</summary>
+<summary><code>target_repo</code> の確認例（スクリーンショット）を表示</summary>
 
 > **参考画像:** リポジトリページのヘッダーに `owner/repo` 形式で表示されています。
 >

--- a/docs/quickstart-gui.md
+++ b/docs/quickstart-gui.md
@@ -17,7 +17,7 @@ flowchart LR
 リポジトリページ右上の「Fork」ボタンをクリックします。
 
 <details>
-<summary>スクリーンショットを表示</summary>
+<summary>Fork ボタンのスクリーンショットを表示</summary>
 
 > **参考画像:** リポジトリページ右上に「Fork」ボタンが表示されています。
 >
@@ -32,7 +32,7 @@ flowchart LR
 GitHub の [Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens) から PAT を作成します。
 
 <details>
-<summary>スクリーンショットを表示</summary>
+<summary>PAT 作成画面のスクリーンショットを表示</summary>
 
 > **参考画像:** Settings > Developer settings > Personal access tokens 画面
 >


### PR DESCRIPTION
## Summary
- `docs/faq.md` と `docs/quickstart-gui.md` の `<details><summary>` 文言を、汎用的な「スクリーンショットを表示」から各セクションに即した具体的な文言に変更
- スクリーンリーダーや同一ページ内での複数 `<details>` 識別性を改善

## 変更内容
| ファイル | 修正前 | 修正後 |
| --- | --- | --- |
| `docs/faq.md` | スクリーンショットを表示 | `project_number` の確認例（スクリーンショット）を表示 |
| `docs/faq.md` | スクリーンショットを表示 | `target_repo` の確認例（スクリーンショット）を表示 |
| `docs/quickstart-gui.md` | スクリーンショットを表示 | Fork ボタンのスクリーンショットを表示 |
| `docs/quickstart-gui.md` | スクリーンショットを表示 | PAT 作成画面のスクリーンショットを表示 |

## Note
Issue では `quickstart-gui.md` に3箇所と記載されていますが、現在のファイルには `<details>` ブロックが2箇所のみのため、既存の2箇所を修正しました。

closes #141

## Test plan
- [ ] 各 `<details>` の折りたたみが正常に動作することを確認
- [ ] `<summary>` の文言が具体的な内容になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)