### PR TITLE
feat: failure-summary を汎用的な workflow-summary に拡張

### DIFF
--- a/.github/actions/workflow-summary/action.yml
+++ b/.github/actions/workflow-summary/action.yml
@@ -1,6 +1,9 @@
-name: 'Failure Summary'
-description: '失敗時の共通サマリー出力'
+name: 'Workflow Summary'
+description: '成功・失敗の共通ワークフローサマリー出力'
 inputs:
+  status:
+    description: 'ワークフローの結果ステータス（success / failure）'
+    required: true
   job-results:
     description: '各ジョブの結果（JSON形式、複数ジョブ時に使用）'
     required: false
@@ -10,6 +13,7 @@ runs:
   steps:
     - shell: bash
       env:
+        STATUS: ${{ inputs.status }}
         JOB_RESULTS: ${{ inputs.job-results }}
       run: |
         # Markdownテーブル用エスケープ: | を \| に、改行をスペースに置換
@@ -17,8 +21,16 @@ runs:
           printf '%s' "$1" | tr '\n' ' ' | sed 's/|/\\|/g'
         }
 
+        if [[ "${STATUS}" == "success" ]]; then
+          ICON=":white_check_mark:"
+          TITLE="ワークフロー成功レポート"
+        else
+          ICON=":x:"
+          TITLE="ワークフロー失敗レポート"
+        fi
+
         {
-          echo "## :x: ワークフロー失敗レポート"
+          echo "## ${ICON} ${TITLE}"
           echo ""
           echo "| 項目 | 値 |"
           echo "|------|-----|"
@@ -27,6 +39,8 @@ runs:
           echo "| コミット | \`${GITHUB_SHA::7}\` |"
           echo "| 実行者 | \`$(escape_md "${{ github.actor }}")\` |"
           echo "| 実行URL | [Actions Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+          echo "| gh バージョン | \`$(gh --version | head -1)\` |"
+          echo "| jq バージョン | \`$(jq --version)\` |"
 
           if [[ -n "${JOB_RESULTS}" ]]; then
             echo ""

--- a/.github/workflows/01-create-project.yml
+++ b/.github/workflows/01-create-project.yml
@@ -50,7 +50,7 @@ jobs:
     secrets:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
 
-  failure-summary:
+  workflow-summary-failure:
     needs: [create-project, extend-project]
     if: failure()
     runs-on: ubuntu-latest
@@ -59,7 +59,23 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: 失敗サマリーを出力
-        uses: ./.github/actions/failure-summary
+        uses: ./.github/actions/workflow-summary
         with:
+          status: failure
+          job-results: |
+            {"create-project": "${{ needs.create-project.result }}", "extend-project": "${{ needs.extend-project.result }}"}
+
+  workflow-summary-success:
+    needs: [create-project, extend-project]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: 成功サマリーを出力
+        uses: ./.github/actions/workflow-summary
+        with:
+          status: success
           job-results: |
             {"create-project": "${{ needs.create-project.result }}", "extend-project": "${{ needs.extend-project.result }}"}

--- a/.github/workflows/02-extend-project.yml
+++ b/.github/workflows/02-extend-project.yml
@@ -19,7 +19,7 @@ jobs:
     secrets:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
 
-  failure-summary:
+  workflow-summary-failure:
     needs: [extend-project]
     if: failure()
     runs-on: ubuntu-latest
@@ -28,7 +28,23 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: 失敗サマリーを出力
-        uses: ./.github/actions/failure-summary
+        uses: ./.github/actions/workflow-summary
         with:
+          status: failure
+          job-results: |
+            {"extend-project": "${{ needs.extend-project.result }}"}
+
+  workflow-summary-success:
+    needs: [extend-project]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: 成功サマリーを出力
+        uses: ./.github/actions/workflow-summary
+        with:
+          status: success
           job-results: |
             {"extend-project": "${{ needs.extend-project.result }}"}

--- a/.github/workflows/03-add-items-to-project.yml
+++ b/.github/workflows/03-add-items-to-project.yml
@@ -60,7 +60,7 @@ jobs:
           chmod +x scripts/add-items-to-project.sh
           bash scripts/add-items-to-project.sh
 
-  failure-summary:
+  workflow-summary-failure:
     needs: [add-items]
     if: failure()
     runs-on: ubuntu-latest
@@ -69,7 +69,23 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: 失敗サマリーを出力
-        uses: ./.github/actions/failure-summary
+        uses: ./.github/actions/workflow-summary
         with:
+          status: failure
+          job-results: |
+            {"add-items": "${{ needs.add-items.result }}"}
+
+  workflow-summary-success:
+    needs: [add-items]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: 成功サマリーを出力
+        uses: ./.github/actions/workflow-summary
+        with:
+          status: success
           job-results: |
             {"add-items": "${{ needs.add-items.result }}"}

--- a/.github/workflows/04-export-project-items.yml
+++ b/.github/workflows/04-export-project-items.yml
@@ -70,7 +70,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  failure-summary:
+  workflow-summary-failure:
     needs: [export-items]
     if: failure()
     runs-on: ubuntu-latest
@@ -79,7 +79,23 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: 失敗サマリーを出力
-        uses: ./.github/actions/failure-summary
+        uses: ./.github/actions/workflow-summary
         with:
+          status: failure
+          job-results: |
+            {"export-items": "${{ needs.export-items.result }}"}
+
+  workflow-summary-success:
+    needs: [export-items]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: 成功サマリーを出力
+        uses: ./.github/actions/workflow-summary
+        with:
+          status: success
           job-results: |
             {"export-items": "${{ needs.export-items.result }}"}


### PR DESCRIPTION
## Summary
- `.github/actions/failure-summary` を `.github/actions/workflow-summary` にリネーム・汎用化
- `status` 入力パラメータ（`success` / `failure`）を追加し、アイコン・タイトルを動的に切り替え
- サマリーテーブルに `gh --version` / `jq --version` のツールバージョン情報を追加
- 全4ワークフローに成功時・失敗時両方のサマリー出力ジョブを導入

## Test plan
- [ ] `01-create-project.yml` を手動実行し、成功時に `:white_check_mark: ワークフロー成功レポート` が表示されることを確認
- [ ] いずれかのワークフローで意図的に失敗させ、`:x: ワークフロー失敗レポート` が表示されることを確認
- [ ] サマリーテーブルに gh / jq バージョンが正しく出力されることを確認

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)