### PR TITLE
feat: ワークフロー失敗時に Issue/Discussion 起票を促すメッセージを出力

### DIFF
--- a/.github/actions/workflow-summary/action.yml
+++ b/.github/actions/workflow-summary/action.yml
@@ -71,7 +71,7 @@ runs:
             fi
           fi
 
-          if [[ "${STATUS}" != "success" ]]; then
+          if [[ "${STATUS}" == "failure" ]]; then
             # フォークの場合はフォーク元リポジトリを取得
             UPSTREAM_REPO=$(gh api "repos/${{ github.repository }}" --jq 'select(.fork) | .parent.full_name' 2>/dev/null || true)
             if [[ -n "${UPSTREAM_REPO}" ]]; then


### PR DESCRIPTION
## Summary
- `workflow-summary` アクションで `status: failure` の場合のみ、サマリーレポート末尾に「次のアクション」セクションを追加
- Issue / Discussion 作成リンクを `github.server_url` と `github.repository` から動的に生成

## Test plan
- [ ] ワークフローを意図的に失敗させ、サマリーに「次のアクション」セクションが表示されることを確認
- [ ] ワークフロー成功時にはセクションが表示されないことを確認
- [ ] Issue / Discussion リンクが正しいURLを指していることを確認

closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)