### PR TITLE
fix: setup-project-fields.sh のサマリー表記を「カスタムフィールド一覧」に修正

### DIFF
--- a/scripts/setup-project-fields.sh
+++ b/scripts/setup-project-fields.sh
@@ -179,7 +179,7 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "| スキップ | ${SKIPPED_COUNT} 件（既存） |"
     echo "| 失敗 | ${FAILED_COUNT} 件 |"
     echo ""
-    echo "### フィールド一覧"
+    echo "### カスタムフィールド一覧"
     echo ""
     echo "| フィールド名 | データ型 | 選択肢 |"
     echo "|-------------|---------|--------|"


### PR DESCRIPTION
## Summary
- `scripts/setup-project-fields.sh` L182 の Job Summary セクション見出しを `### フィールド一覧` から `### カスタムフィールド一覧` に修正

## Test plan
- [ ] ワークフロー実行後の Job Summary で「カスタムフィールド一覧」と表示されることを確認

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)