### PR TITLE
docs: developers.md のツリー構造内 # コメントの位置ずれを修正

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -55,7 +55,7 @@ scripts/
   ├── setup-github-project.sh      # Project 作成スクリプト
   ├── setup-project-fields.sh      # カスタムフィールド作成スクリプト
   ├── setup-project-status.sh      # ステータスカラム設定スクリプト
-  ├── setup-project-views.sh      # View 作成スクリプト
+  ├── setup-project-views.sh       # View 作成スクリプト
   ├── add-items-to-project.sh      # アイテム一括追加スクリプト
   └── export-project-items.sh      # アイテムエクスポートスクリプト
 ```
@@ -67,11 +67,11 @@ scripts/
 ```
 01-create-project.yml
   ├── create-project ジョブ
-  │   └── scripts/setup-github-project.sh   # Project 作成
+  │   └── scripts/setup-github-project.sh    # Project 作成
   ├── extend-project ジョブ（_reusable-extend-project.yml）
   │   ├── scripts/setup-project-fields.sh    # カスタムフィールド作成
   │   ├── scripts/setup-project-status.sh    # ステータスカラム設定
-  │   └── scripts/setup-project-views.sh    # View 作成
+  │   └── scripts/setup-project-views.sh     # View 作成
   ├── workflow-summary-failure ジョブ（失敗時）
   │   └── .github/actions/workflow-summary   # 失敗サマリー出力
   └── workflow-summary-success ジョブ（成功時）
@@ -85,7 +85,7 @@ scripts/
   ├── extend-project ジョブ（_reusable-extend-project.yml）
   │   ├── scripts/setup-project-fields.sh    # カスタムフィールド作成
   │   ├── scripts/setup-project-status.sh    # ステータスカラム設定
-  │   └── scripts/setup-project-views.sh    # View 作成
+  │   └── scripts/setup-project-views.sh     # View 作成
   ├── workflow-summary-failure ジョブ（失敗時）
   │   └── .github/actions/workflow-summary   # 失敗サマリー出力
   └── workflow-summary-success ジョブ（成功時）


### PR DESCRIPTION
## Summary
- `docs/developers.md` のツリー構造内の `#` コメントの水平位置が揃っていない4箇所を修正
  - L58: `setup-project-views.sh`（構成ファイルセクション）
  - L70: `scripts/setup-github-project.sh`（① GitHub Project 新規作成セクション）
  - L74: `scripts/setup-project-views.sh`（① GitHub Project 新規作成セクション）
  - L88: `scripts/setup-project-views.sh`（② GitHub Project 拡張セクション）

Closes #159

## Test plan
- [ ] 各セクション内の `#` コメントが垂直方向に揃って表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)