### PR TITLE
docs: add-items-to-project のフローチャートでメインフローとサブグラフを接続

### DIFF
--- a/docs/scripts/add-items-to-project.md
+++ b/docs/scripts/add-items-to-project.md
@@ -27,11 +27,13 @@ flowchart TD
     E --> F{"ITEM_TYPE に\nIssue を含む?"}
     F -- "Yes" --> G["fetch_and_add_items\n（Issue）"]
     F -- "No" --> H{"ITEM_TYPE に\nPR を含む?"}
-    G --> H
+    G --> M
+    V --> H
 
     H -- "Yes" --> I["fetch_and_add_items\n（PR）"]
     H -- "No" --> J["サマリー出力"]
-    I --> J
+    I --> M
+    V --> J
     J --> K["完了"]
 
     subgraph L["fetch_and_add_items 関数"]


### PR DESCRIPTION
## Summary
- メインフローの `fetch_and_add_items` 呼び出しノード (`G`, `I`) からサブグラフ内の開始ノード (`M`) への接続を追加
- サブグラフの終了ノード (`V`) からメインフローへの復帰接続 (`V --> H`, `V --> J`) を追加
- これによりフローチャートが1つのまとまった図として表示されるように修正

Closes #160

## Test plan
- [ ] MkDocs でローカルプレビューし、フローチャートが1つの連結した図として表示されることを確認
- [ ] サブグラフがメインフローの適切な位置に接続されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)