### PR TITLE
docs: <details><summary> にクリックヒントを追加

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ GitHub Project の URL 末尾の数字が `project_number` です。
 **例:** `https://github.com/users/octocat/projects/3` → `project_number` は **3**
 
 <details>
-<summary><code>project_number</code> の確認例（スクリーンショット）を表示</summary>
+<summary><code>project_number</code> の確認例（スクリーンショット）を表示（ここをクリック→）</summary>
 
 > **参考画像:** Organization の Projects 一覧画面では、各プロジェクト名の下に `#番号` が表示されます。
 >
@@ -41,7 +41,7 @@ gh project list
 **例:** `https://github.com/octocat/my-app` → `target_repo` は **octocat/my-app**
 
 <details>
-<summary><code>target_repo</code> の確認例（スクリーンショット）を表示</summary>
+<summary><code>target_repo</code> の確認例（スクリーンショット）を表示（ここをクリック→）</summary>
 
 > **参考画像:** リポジトリページのヘッダーに `owner/repo` 形式で表示されています。
 >

--- a/docs/quickstart-gui.md
+++ b/docs/quickstart-gui.md
@@ -17,7 +17,7 @@ flowchart LR
 リポジトリページ右上の「Fork」ボタンをクリックします。
 
 <details>
-<summary>Fork ボタンのスクリーンショットを表示</summary>
+<summary>Fork ボタンのスクリーンショットを表示（ここをクリック→）</summary>
 
 > **参考画像:** リポジトリページ右上に「Fork」ボタンが表示されています。
 >
@@ -32,7 +32,7 @@ flowchart LR
 GitHub の [Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens) から PAT を作成します。
 
 <details>
-<summary>PAT 作成画面のスクリーンショットを表示</summary>
+<summary>PAT 作成画面のスクリーンショットを表示（ここをクリック→）</summary>
 
 > **参考画像:** Settings > Developer settings > Personal access tokens 画面
 >


### PR DESCRIPTION
## Summary
- `<summary>` タグ内のテキスト末尾に「（ここをクリック→）」を追加し、アコーディオンがクリック可能であることを明示
- 対象: `docs/quickstart-gui.md`（2箇所）、`docs/faq.md`（2箇所）

Closes #163

## Test plan
- [ ] GitHub Pages でプレビューし、`<details>` 要素にクリックヒントが表示されることを確認
- [ ] アコーディオンの開閉動作が正常に機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)