### PR TITLE
docs: スクリプト内の日本語メッセージもGitHub公式表記に統一する

### DIFF
--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -32,7 +32,7 @@ detect_owner_type
 
 if [[ "${OWNER_TYPE}" == "User" ]]; then
   echo ""
-  echo "個人アカウントとして検出されました。"
+  echo "個人用アカウントとして検出されました。"
   echo "必要な PAT 権限: Account permissions > Projects > Read and write"
 elif [[ "${OWNER_TYPE}" == "Organization" ]]; then
   echo ""


### PR DESCRIPTION
## Summary
- `scripts/setup-github-project.sh` 内の「個人アカウント」を GitHub 公式日本語ドキュメントに準拠した「個人用アカウント」に修正

## 関連Issue
Close #170

## Test plan
- [ ] `scripts/setup-github-project.sh` を個人用アカウントで実行し、メッセージ表記が「個人用アカウントとして検出されました。」になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)