### PR TITLE
fix: アイテム取得件数の上限をAPIの最大値(100)に引き上げ

### DIFF
--- a/scripts/add-items-to-project.sh
+++ b/scripts/add-items-to-project.sh
@@ -247,7 +247,7 @@ fetch_and_add_items() {
   fi
 
   # 1回の取得で処理するアイテム数の上限
-  local list_args=(--repo "${TARGET_REPO}" --state "${ITEM_STATE}" --limit 10 --json url,state --jq '.[] | [.url, .state] | @tsv')
+  local list_args=(--repo "${TARGET_REPO}" --state "${ITEM_STATE}" --limit 100 --json url,state --jq '.[] | [.url, .state] | @tsv')
   if [[ -n "${ITEM_LABEL}" ]]; then
     list_args+=(--label "${ITEM_LABEL}")
   fi


### PR DESCRIPTION
## Summary
- `scripts/add-items-to-project.sh` の `--limit 10` を `--limit 100`（GitHub GraphQL API の最大取得件数）に変更
- 動作確認のために引き下げていた設定を本来の値に戻す

Closes #175

## Test plan
- [ ] `add-items-to-project.sh` を実行し、100件までアイテムが正常に取得・処理されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)