### PR TITLE
docs: setup-github-project.md にパラメータ上限セクションを追加

### DIFF
--- a/docs/scripts/setup-github-project.md
+++ b/docs/scripts/setup-github-project.md
@@ -72,6 +72,12 @@ flowchart TD
 
 REST API バージョン `2022-11-28` を使用します。共通ライブラリ（`lib/common.sh`）がオーナータイプ判定時に `X-GitHub-Api-Version: 2022-11-28` ヘッダを自動付与します。
 
+### パラメータ上限
+
+| パラメータ | 現在の値 | 備考 |
+|-----------|---------|------|
+| `projectsV2(first: N)` | 100 | 既存 Project 重複チェック用のページサイズ |
+
 ## 使用ワークフロー
 
 - [① GitHub Project 新規作成](../workflows/01-create-project)


### PR DESCRIPTION
## Summary
- `docs/scripts/setup-github-project.md` に「パラメータ上限」セクションを追加
- 他のドキュメント（`add-items-to-project.md`、`setup-project-status.md` 等）との整合性を確保
- `projectsV2(first: 100)` のパラメータ情報を記載

## Test plan
- [ ] 追加されたセクションのフォーマットが他のドキュメントと一致していることを確認
- [ ] Markdownのテーブルが正しくレンダリングされることを確認

closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)