### PR TITLE
fix: アーティファクト保持期間を7日に統一（#261）

### DIFF
--- a/.github/workflows/05-analyze-project.yml
+++ b/.github/workflows/05-analyze-project.yml
@@ -78,7 +78,7 @@ jobs:
           name: summary-report-${{ inputs.project_number }}
           path: report-*-summary.*
           if-no-files-found: ignore
-          retention-days: 90
+          retention-days: 7
 
   generate-effort-report:
     if: >-
@@ -107,7 +107,7 @@ jobs:
           name: effort-report-${{ inputs.project_number }}
           path: report-*-effort.*
           if-no-files-found: ignore
-          retention-days: 90
+          retention-days: 7
 
   detect-stale-items:
     if: >-

--- a/docs/workflows/05-analyze-project.md
+++ b/docs/workflows/05-analyze-project.md
@@ -163,7 +163,7 @@
 
 #### Artifact
 
-`report-{number}-summary.{json|md|csv|tsv}` が artifact としてダウンロード可能です（保持期間: 90 日）。出力形式は `output_format` パラメータで選択できます。
+`report-{number}-summary.{json|md|csv|tsv}` が artifact としてダウンロード可能です（保持期間: 7 日）。出力形式は `output_format` パラメータで選択できます。
 
 ---
 
@@ -211,7 +211,7 @@
 
 #### Artifact
 
-`report-{number}-effort.{json|md|csv|tsv}` が artifact としてダウンロード可能です（保持期間: 90 日）。出力形式は `output_format` パラメータで選択できます。
+`report-{number}-effort.{json|md|csv|tsv}` が artifact としてダウンロード可能です（保持期間: 7 日）。出力形式は `output_format` パラメータで選択できます。
 
 ---
 


### PR DESCRIPTION
## Summary
- `generate-summary-report` と `generate-effort-report` ジョブの `retention-days` を 90 → 7 に変更
- `docs/workflows/05-analyze-project.md` の保持期間の記載を 90 日 → 7 日に修正

## Test plan
- [ ] ワークフロー YAML の全ジョブで `retention-days: 7` になっていること確認
- [ ] ドキュメントの Artifact 保持期間の記載が全て 7 日になっていること確認

Close #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)