### PR TITLE
feat: レポート出力から機密フィールドを除外するオプションを追加（#263）

### DIFF
--- a/.github/workflows/05-analyze-project.yml
+++ b/.github/workflows/05-analyze-project.yml
@@ -46,6 +46,11 @@ on:
           - all
           - open
           - closed
+      redact_sensitive:
+        description: "機密フィールド（担当者名・工数など）をレポートから除外する"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -62,6 +67,7 @@ jobs:
       OUTPUT_FORMAT: ${{ inputs.output_format }}
       ITEM_TYPE: ${{ inputs.item_type }}
       ITEM_STATE: ${{ inputs.item_state }}
+      REDACT_SENSITIVE: ${{ inputs.redact_sensitive }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
@@ -91,6 +97,7 @@ jobs:
       OUTPUT_FORMAT: ${{ inputs.output_format }}
       ITEM_TYPE: ${{ inputs.item_type }}
       ITEM_STATE: ${{ inputs.item_state }}
+      REDACT_SENSITIVE: ${{ inputs.redact_sensitive }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
@@ -120,6 +127,7 @@ jobs:
       OUTPUT_FORMAT: ${{ inputs.output_format }}
       ITEM_TYPE: ${{ inputs.item_type }}
       ITEM_STATE: ${{ inputs.item_state }}
+      REDACT_SENSITIVE: ${{ inputs.redact_sensitive }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
@@ -149,6 +157,7 @@ jobs:
       OUTPUT_FORMAT: ${{ inputs.output_format }}
       ITEM_TYPE: ${{ inputs.item_type }}
       ITEM_STATE: ${{ inputs.item_state }}
+      REDACT_SENSITIVE: ${{ inputs.redact_sensitive }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/docs/workflows/05-analyze-project.md
+++ b/docs/workflows/05-analyze-project.md
@@ -28,6 +28,7 @@
 | `output_format` | 出力形式 | — | `choice` | `json` | `markdown` |
 | `item_type` | 対象アイテムの種別 | — | `choice` | `all` | `issues` |
 | `item_state` | 対象アイテムの状態 | — | `choice` | `all` | `open` |
+| `redact_sensitive` | 機密フィールドの除外 | — | `boolean` | `false` | `true` |
 
 ### `report_types` の選択肢
 
@@ -63,6 +64,19 @@
 | `all` | 全状態のアイテムを対象 |
 | `open` | Open 状態のアイテムのみを対象 |
 | `closed` | Closed / Merged 状態のアイテムのみを対象 |
+
+### `redact_sensitive` の動作
+
+`true` に設定すると、アーティファクトのレポートから機密性の高いフィールドが除外されます。Public リポジトリでアーティファクトが第三者にダウンロードされるリスクがある場合に使用してください。
+
+| 除外対象 | 影響を受けるレポート | 説明 |
+|----------|---------------------|------|
+| 担当者名（`assignees`） | 全レポート | 担当者カラム・担当者別集計セクションを除外 |
+| 作成者名（`author`） | summary, effort, export | 作成者カラムを除外 |
+| 工数（`estimated_hours`, `actual_hours`） | summary, effort（CSV/TSV） | フラットデータ出力から除外（集計値は維持） |
+| スケジュール（`planned_start/end`, `actual_start/end`） | effort（CSV/TSV） | フラットデータ出力から除外 |
+
+> **Note:** `REDACT_SENSITIVE` 環境変数を `true` に設定することで、ワークフロー外からも同じリダクション機能を利用できます。
 
 ---
 

--- a/scripts/detect-stale-items.sh
+++ b/scripts/detect-stale-items.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 #   PROJECT_NUMBER - 対象 Project の Number
 #   ITEM_TYPE      - 対象アイテムの種別（all / issues / prs、デフォルト: all）
 #   ITEM_STATE     - 対象アイテムの状態（open / closed / all、デフォルト: all）
-#   OUTPUT_FORMAT  - 出力形式（json / markdown / csv / tsv、デフォルト: json）
+#   OUTPUT_FORMAT     - 出力形式（json / markdown / csv / tsv、デフォルト: json）
+#   REDACT_SENSITIVE  - 機密フィールドをリダクション（true / false、デフォルト: false）
 
 # --- 共通ライブラリ読み込み ---
 
@@ -25,6 +26,7 @@ STALE_DAYS_IN_REVIEW=3
 EXCLUDE_LABELS="on-hold,blocked"
 ITEM_TYPE="${ITEM_TYPE:-all}"
 ITEM_STATE="${ITEM_STATE:-all}"
+REDACT_SENSITIVE="${REDACT_SENSITIVE:-false}"
 
 # --- バリデーション ---
 
@@ -241,6 +243,14 @@ STALE_ITEMS=$(echo "${ITEMS}" | jq \
 ')
 
 STALE_COUNT=$(echo "${STALE_ITEMS}" | jq 'length')
+
+# --- 機密フィールドのリダクション ---
+
+if is_redact_enabled; then
+  echo "  機密フィールドをリダクションしています..."
+  STALE_ITEMS=$(echo "${STALE_ITEMS}" | jq '[.[] | .assignees = "***"]')
+fi
+
 echo "  滞留アイテム: ${STALE_COUNT} 件"
 
 # --- ステータス別集計 ---
@@ -258,8 +268,17 @@ read -r IN_REVIEW_COUNT IN_PROGRESS_COUNT TODO_COUNT < <(echo "${STALE_ITEMS}" |
 format_stale_markdown() {
   local stale_items="$1"
 
-  local md_row_filter="${JQ_MD_ESCAPE}"'
-    "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(.repository) | \(if .assignees == "" then "-" else (.assignees | md_escape) end) | \(.updated_at | split("T")[0]) | \(.days_stale) |"'
+  if is_redact_enabled; then
+    local md_row_filter="${JQ_MD_ESCAPE}"'
+      "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(.repository) | \(.updated_at | split("T")[0]) | \(.days_stale) |"'
+    local table_header="| # | タイトル | リポジトリ | 最終更新 | 経過日数 |"
+    local table_separator="|---|---------|-----------|---------|---------|"
+  else
+    local md_row_filter="${JQ_MD_ESCAPE}"'
+      "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(.repository) | \(if .assignees == "" then "-" else (.assignees | md_escape) end) | \(.updated_at | split("T")[0]) | \(.days_stale) |"'
+    local table_header="| # | タイトル | リポジトリ | アサイン | 最終更新 | 経過日数 |"
+    local table_separator="|---|---------|-----------|---------|---------|---------|"
+  fi
 
   {
     echo "# 滞留アイテムレポート"
@@ -275,8 +294,8 @@ format_stale_markdown() {
       if [[ "${IN_REVIEW_COUNT}" -gt 0 ]]; then
         echo "## In Review（${STALE_DAYS_IN_REVIEW} 日以上）: ${IN_REVIEW_COUNT} 件"
         echo ""
-        echo "| # | タイトル | リポジトリ | アサイン | 最終更新 | 経過日数 |"
-        echo "|---|---------|-----------|---------|---------|---------|"
+        echo "${table_header}"
+        echo "${table_separator}"
         echo "${stale_items}" | jq -r "[.[] | select(.status == \"In Review\")] | sort_by(-.days_stale)[] | ${md_row_filter}"
         echo ""
       fi
@@ -284,8 +303,8 @@ format_stale_markdown() {
       if [[ "${IN_PROGRESS_COUNT}" -gt 0 ]]; then
         echo "## In Progress（${STALE_DAYS_IN_PROGRESS} 日以上）: ${IN_PROGRESS_COUNT} 件"
         echo ""
-        echo "| # | タイトル | リポジトリ | アサイン | 最終更新 | 経過日数 |"
-        echo "|---|---------|-----------|---------|---------|---------|"
+        echo "${table_header}"
+        echo "${table_separator}"
         echo "${stale_items}" | jq -r "[.[] | select(.status == \"In Progress\")] | sort_by(-.days_stale)[] | ${md_row_filter}"
         echo ""
       fi
@@ -293,8 +312,8 @@ format_stale_markdown() {
       if [[ "${TODO_COUNT}" -gt 0 ]]; then
         echo "## Todo（${STALE_DAYS_TODO} 日以上）: ${TODO_COUNT} 件"
         echo ""
-        echo "| # | タイトル | リポジトリ | アサイン | 最終更新 | 経過日数 |"
-        echo "|---|---------|-----------|---------|---------|---------|"
+        echo "${table_header}"
+        echo "${table_separator}"
         echo "${stale_items}" | jq -r "[.[] | select(.status == \"Todo\")] | sort_by(-.days_stale)[] | ${md_row_filter}"
         echo ""
       fi
@@ -304,14 +323,24 @@ format_stale_markdown() {
 
 format_stale_csv() {
   local stale_items="$1"
-  echo "type,number,title,url,status,repository,assignees,updated_at,days_stale,threshold"
-  echo "${stale_items}" | jq -r '.[] | [.type, .number, .title, .url, .status, .repository, .assignees, .updated_at, .days_stale, .threshold] | @csv'
+  if is_redact_enabled; then
+    echo "type,number,title,url,status,repository,updated_at,days_stale,threshold"
+    echo "${stale_items}" | jq -r '.[] | [.type, .number, .title, .url, .status, .repository, .updated_at, .days_stale, .threshold] | @csv'
+  else
+    echo "type,number,title,url,status,repository,assignees,updated_at,days_stale,threshold"
+    echo "${stale_items}" | jq -r '.[] | [.type, .number, .title, .url, .status, .repository, .assignees, .updated_at, .days_stale, .threshold] | @csv'
+  fi
 }
 
 format_stale_tsv() {
   local stale_items="$1"
-  echo -e "type\tnumber\ttitle\turl\tstatus\trepository\tassignees\tupdated_at\tdays_stale\tthreshold"
-  echo "${stale_items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .status, .repository, .assignees, .updated_at, (.days_stale | tostring), (.threshold | tostring)] | @tsv'
+  if is_redact_enabled; then
+    echo -e "type\tnumber\ttitle\turl\tstatus\trepository\tupdated_at\tdays_stale\tthreshold"
+    echo "${stale_items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .status, .repository, .updated_at, (.days_stale | tostring), (.threshold | tostring)] | @tsv'
+  else
+    echo -e "type\tnumber\ttitle\turl\tstatus\trepository\tassignees\tupdated_at\tdays_stale\tthreshold"
+    echo "${stale_items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .status, .repository, .assignees, .updated_at, (.days_stale | tostring), (.threshold | tostring)] | @tsv'
+  fi
 }
 
 # --- レポート出力 ---
@@ -367,6 +396,9 @@ case "${OUTPUT_FORMAT}" in
         }]
       }
     ')
+    if is_redact_enabled; then
+      REPORT_JSON=$(echo "${REPORT_JSON}" | jq '.stale_items = [.stale_items[] | del(.assignees)]')
+    fi
     echo "${REPORT_JSON}" > "${OUTPUT_FILE}"
     ;;
   markdown)

--- a/scripts/export-project-items.sh
+++ b/scripts/export-project-items.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 #   PROJECT_NUMBER - 対象 Project の Number
 #   OUTPUT_FORMAT  - 出力形式（markdown / csv / tsv / json、デフォルト: markdown）
 #   ITEM_TYPE      - 対象アイテムの種別（all / issues / prs、デフォルト: all）
-#   ITEM_STATE     - 取得するアイテムの状態（open / closed / all、デフォルト: all）
+#   ITEM_STATE        - 取得するアイテムの状態（open / closed / all、デフォルト: all）
+#   REDACT_SENSITIVE  - 機密フィールドをリダクション（true / false、デフォルト: false）
 
 # --- 共通ライブラリ読み込み ---
 
@@ -26,6 +27,7 @@ validate_enum "OUTPUT_FORMAT" "${OUTPUT_FORMAT}" "markdown" "csv" "tsv" "json"
 
 ITEM_TYPE="${ITEM_TYPE:-all}"
 ITEM_STATE="${ITEM_STATE:-all}"
+REDACT_SENSITIVE="${REDACT_SENSITIVE:-false}"
 validate_enum "ITEM_TYPE" "${ITEM_TYPE}" "all" "issues" "prs"
 validate_enum "ITEM_STATE" "${ITEM_STATE}" "open" "closed" "all"
 
@@ -149,9 +151,17 @@ format_markdown() {
   local issue_count pr_count
   read -r issue_count pr_count < <(echo "${items}" | jq -r '[([.[] | select(.type == "Issue")] | length), ([.[] | select(.type == "PullRequest")] | length)] | @tsv')
 
-  # Markdown テーブル行の jq フィルタ（特殊文字をエスケープし、日付を YYYY-MM-DD に変換）
-  local md_row_filter="${JQ_MD_ESCAPE}"'
-    "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(.state) | \(.repository) | \(.author) | \(.assignees | md_escape) | \(.labels | md_escape) | \(.created_at | split("T")[0]) | \(.updated_at | split("T")[0]) |"'
+  if is_redact_enabled; then
+    local md_row_filter="${JQ_MD_ESCAPE}"'
+      "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(.state) | \(.repository) | \(.labels | md_escape) | \(.created_at | split(\"T\")[0]) | \(.updated_at | split(\"T\")[0]) |"'
+    local table_header="| # | タイトル | 状態 | リポジトリ | ラベル | 作成日 | 更新日 |"
+    local table_separator="|---|---------|------|-----------|--------|--------|--------|"
+  else
+    local md_row_filter="${JQ_MD_ESCAPE}"'
+      "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(.state) | \(.repository) | \(.author) | \(.assignees | md_escape) | \(.labels | md_escape) | \(.created_at | split(\"T\")[0]) | \(.updated_at | split(\"T\")[0]) |"'
+    local table_header="| # | タイトル | 状態 | リポジトリ | 作成者 | アサイン | ラベル | 作成日 | 更新日 |"
+    local table_separator="|---|---------|------|-----------|--------|---------|--------|--------|--------|"
+  fi
 
   {
     echo "# Project アイテム一覧"
@@ -166,8 +176,8 @@ format_markdown() {
     if [[ "${issue_count}" -gt 0 ]]; then
       echo "## Issues"
       echo ""
-      echo "| # | タイトル | 状態 | リポジトリ | 作成者 | アサイン | ラベル | 作成日 | 更新日 |"
-      echo "|---|---------|------|-----------|--------|---------|--------|--------|--------|"
+      echo "${table_header}"
+      echo "${table_separator}"
       echo "${items}" | jq -r ".[] | select(.type == \"Issue\") | ${md_row_filter}"
       echo ""
     fi
@@ -175,8 +185,8 @@ format_markdown() {
     if [[ "${pr_count}" -gt 0 ]]; then
       echo "## Pull Requests"
       echo ""
-      echo "| # | タイトル | 状態 | リポジトリ | 作成者 | アサイン | ラベル | 作成日 | 更新日 |"
-      echo "|---|---------|------|-----------|--------|---------|--------|--------|--------|"
+      echo "${table_header}"
+      echo "${table_separator}"
       echo "${items}" | jq -r ".[] | select(.type == \"PullRequest\") | ${md_row_filter}"
       echo ""
     fi
@@ -185,19 +195,33 @@ format_markdown() {
 
 format_csv() {
   local items="$1"
-  echo "type,number,title,url,state,repository,author,assignees,labels,created_at,updated_at"
-  echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, .author, .assignees, .labels, .created_at, .updated_at] | @csv'
+  if is_redact_enabled; then
+    echo "type,number,title,url,state,repository,labels,created_at,updated_at"
+    echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, .labels, .created_at, .updated_at] | @csv'
+  else
+    echo "type,number,title,url,state,repository,author,assignees,labels,created_at,updated_at"
+    echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, .author, .assignees, .labels, .created_at, .updated_at] | @csv'
+  fi
 }
 
 format_tsv() {
   local items="$1"
-  echo -e "type\tnumber\ttitle\turl\tstate\trepository\tauthor\tassignees\tlabels\tcreated_at\tupdated_at"
-  echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, .author, .assignees, .labels, .created_at, .updated_at] | @tsv'
+  if is_redact_enabled; then
+    echo -e "type\tnumber\ttitle\turl\tstate\trepository\tlabels\tcreated_at\tupdated_at"
+    echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, .labels, .created_at, .updated_at] | @tsv'
+  else
+    echo -e "type\tnumber\ttitle\turl\tstate\trepository\tauthor\tassignees\tlabels\tcreated_at\tupdated_at"
+    echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, .author, .assignees, .labels, .created_at, .updated_at] | @tsv'
+  fi
 }
 
 format_json() {
   local items="$1"
-  echo "${items}" | jq '.'
+  if is_redact_enabled; then
+    echo "${items}" | jq '[.[] | del(.author, .assignees)]'
+  else
+    echo "${items}" | jq '.'
+  fi
 }
 
 # --- アイテム取得 ---
@@ -221,6 +245,13 @@ ITEMS=$(echo "${ITEMS}" | filter_items_by_state)
 read -r TOTAL_COUNT ISSUE_COUNT PR_COUNT < <(echo "${ITEMS}" | jq -r '[length, ([.[] | select(.type == "Issue")] | length), ([.[] | select(.type == "PullRequest")] | length)] | @tsv')
 
 echo "  合計: ${TOTAL_COUNT} 件（Issue: ${ISSUE_COUNT}, PR: ${PR_COUNT}）"
+
+# --- 機密フィールドのリダクション ---
+
+if is_redact_enabled; then
+  echo "  機密フィールドをリダクションしています..."
+  ITEMS=$(echo "${ITEMS}" | jq '[.[] | .author = "***" | .assignees = "***"]')
+fi
 
 if [[ "${TOTAL_COUNT}" -eq 0 ]]; then
   echo "::warning::対象の Issue / Pull Request が見つかりませんでした。"

--- a/scripts/generate-effort-report.sh
+++ b/scripts/generate-effort-report.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 #   PROJECT_NUMBER - 対象 Project の Number
 #   ITEM_TYPE      - 対象アイテムの種別（all / issues / prs、デフォルト: all）
 #   ITEM_STATE     - 対象アイテムの状態（open / closed / all、デフォルト: all）
-#   OUTPUT_FORMAT  - 出力形式（json / markdown / csv / tsv、デフォルト: json）
+#   OUTPUT_FORMAT     - 出力形式（json / markdown / csv / tsv、デフォルト: json）
+#   REDACT_SENSITIVE  - 機密フィールドをリダクション（true / false、デフォルト: false）
 
 # --- 共通ライブラリ読み込み ---
 
@@ -23,6 +24,7 @@ VARIANCE_THRESHOLD=10
 VARIANCE_TOP_N=10
 ITEM_TYPE="${ITEM_TYPE:-all}"
 ITEM_STATE="${ITEM_STATE:-all}"
+REDACT_SENSITIVE="${REDACT_SENSITIVE:-false}"
 
 # --- バリデーション ---
 
@@ -187,6 +189,13 @@ ITEMS=$(echo "${ITEMS}" | filter_items_by_state)
 TOTAL_COUNT=$(echo "${ITEMS}" | jq 'length')
 echo "  合計: ${TOTAL_COUNT} 件（フィルタ後）"
 
+# --- 機密フィールドのリダクション ---
+
+if is_redact_enabled; then
+  echo "  機密フィールドをリダクションしています..."
+  ITEMS=$(echo "${ITEMS}" | jq '[.[] | .author = "***" | .assignees = ["***"]]')
+fi
+
 # --- 工数集計 ---
 
 echo ""
@@ -222,29 +231,33 @@ echo "  工数入力済み: ${ITEMS_WITH_EFFORT_COUNT} 件 / 未入力: ${ITEMS_
 echo "  総見積もり工数: ${TOTAL_ESTIMATED} h / 総実績工数: ${TOTAL_ACTUAL} h"
 
 # 担当者別工数集計
-ASSIGNEE_EFFORT=$(echo "${ITEMS}" | jq '
-  [.[] | select(.estimated_hours != null or .actual_hours != null) | . as $item |
-    (if (.assignees | length) == 0 then ["(未アサイン)"] else .assignees end)[]
-    | {
-        assignee: .,
-        estimated_hours: $item.estimated_hours,
-        actual_hours: $item.actual_hours
-      }
-  ]
-  | sort_by(.assignee) | group_by(.assignee)
-  | map({
-      assignee: .[0].assignee,
-      count: length,
-      estimated_hours: ([.[].estimated_hours // 0] | add),
-      actual_hours: ([.[].actual_hours // 0] | add),
-      variance_rate: (
-        if ([.[].estimated_hours // 0] | add) > 0 then
-          ((([.[].actual_hours // 0] | add) - ([.[].estimated_hours // 0] | add)) / ([.[].estimated_hours // 0] | add) * 1000 | round / 10)
-        else null end
-      )
-    })
-  | sort_by(-.estimated_hours)
-')
+if is_redact_enabled; then
+  ASSIGNEE_EFFORT="[]"
+else
+  ASSIGNEE_EFFORT=$(echo "${ITEMS}" | jq '
+    [.[] | select(.estimated_hours != null or .actual_hours != null) | . as $item |
+      (if (.assignees | length) == 0 then ["(未アサイン)"] else .assignees end)[]
+      | {
+          assignee: .,
+          estimated_hours: $item.estimated_hours,
+          actual_hours: $item.actual_hours
+        }
+    ]
+    | sort_by(.assignee) | group_by(.assignee)
+    | map({
+        assignee: .[0].assignee,
+        count: length,
+        estimated_hours: ([.[].estimated_hours // 0] | add),
+        actual_hours: ([.[].actual_hours // 0] | add),
+        variance_rate: (
+          if ([.[].estimated_hours // 0] | add) > 0 then
+            ((([.[].actual_hours // 0] | add) - ([.[].estimated_hours // 0] | add)) / ([.[].estimated_hours // 0] | add) * 1000 | round / 10)
+          else null end
+        )
+      })
+    | sort_by(-.estimated_hours)
+  ')
+fi
 
 # ステータス別工数集計
 STATUS_EFFORT=$(echo "${ITEMS}" | jq --argjson total_estimated "${TOTAL_ESTIMATED}" '
@@ -285,6 +298,9 @@ VARIANCE_ITEMS=$(echo "${ITEMS}" | jq --argjson threshold "${VARIANCE_THRESHOLD}
 ')
 
 VARIANCE_ITEMS_COUNT=$(echo "${VARIANCE_ITEMS}" | jq 'length')
+if is_redact_enabled; then
+  VARIANCE_ITEMS=$(echo "${VARIANCE_ITEMS}" | jq '[.[] | .assignees = ["***"] | .author = "***"]')
+fi
 
 echo "  担当者別: $(echo "${ASSIGNEE_EFFORT}" | jq 'length') 件"
 echo "  ステータス別: $(echo "${STATUS_EFFORT}" | jq 'length') 件"
@@ -338,6 +354,10 @@ if [[ "${HAS_LEAD_TIME}" == "true" ]]; then
     ] | sort_by(-.actual_days)
   ')
 
+  if is_redact_enabled; then
+    LEAD_TIME_ITEMS=$(echo "${LEAD_TIME_ITEMS}" | jq '[.[] | .assignees = ["***"]]')
+  fi
+
   echo "  リードタイム分析対象: $(echo "${LEAD_TIME_ITEMS}" | jq 'length') 件"
 fi
 
@@ -357,6 +377,10 @@ MISSING_EFFORT_ITEMS=$(echo "${ITEMS}" | jq '
   ]
   | sort_by(if .is_done then 0 else 1 end, .number)
 ')
+
+if is_redact_enabled; then
+  MISSING_EFFORT_ITEMS=$(echo "${MISSING_EFFORT_ITEMS}" | jq '[.[] | .assignees = ["***"]]')
+fi
 
 MISSING_EFFORT_COUNT=$(echo "${MISSING_EFFORT_ITEMS}" | jq 'length')
 MISSING_EFFORT_DONE_COUNT=$(echo "${MISSING_EFFORT_ITEMS}" | jq '[.[] | select(.is_done)] | length')
@@ -396,28 +420,30 @@ format_effort_markdown() {
     echo ""
 
     # 担当者別工数
-    local assignee_count
-    assignee_count=$(echo "${ASSIGNEE_EFFORT}" | jq 'length')
-    if [[ "${assignee_count}" -gt 0 ]]; then
-      echo "## 担当者別工数"
-      echo ""
-      echo "| 担当者 | アイテム数 | 見積もり(h) | 実績(h) | 乖離率 |"
-      echo "|---|---|---|---|---|"
-      echo "${ASSIGNEE_EFFORT}" | jq -r '.[] | "| \(.assignee) | \(.count) | \(.estimated_hours) | \(.actual_hours) | \(if .variance_rate != null then (if .variance_rate >= 0 then "+\(.variance_rate)%" else "\(.variance_rate)%" end) else "-" end) |"'
-      echo ""
-
-      echo "> **Note:** 複数担当者がアサインされたアイテムは、各担当者に同一工数が計上されます。担当者別の合計は全体合計と一致しない場合があります。"
-      echo ""
-
-      # Mermaid 円グラフ
-      local has_actual
-      has_actual=$(echo "${ASSIGNEE_EFFORT}" | jq '[.[] | select(.actual_hours > 0)] | length')
-      if [[ "${has_actual}" -gt 0 ]]; then
-        echo '```mermaid'
-        echo 'pie title 担当者別実績工数'
-        echo "${ASSIGNEE_EFFORT}" | jq -r '.[] | select(.actual_hours > 0) | "    \"\(.assignee)\" : \(.actual_hours)"'
-        echo '```'
+    if ! is_redact_enabled; then
+      local assignee_count
+      assignee_count=$(echo "${ASSIGNEE_EFFORT}" | jq 'length')
+      if [[ "${assignee_count}" -gt 0 ]]; then
+        echo "## 担当者別工数"
         echo ""
+        echo "| 担当者 | アイテム数 | 見積もり(h) | 実績(h) | 乖離率 |"
+        echo "|---|---|---|---|---|"
+        echo "${ASSIGNEE_EFFORT}" | jq -r '.[] | "| \(.assignee) | \(.count) | \(.estimated_hours) | \(.actual_hours) | \(if .variance_rate != null then (if .variance_rate >= 0 then "+\(.variance_rate)%" else "\(.variance_rate)%" end) else "-" end) |"'
+        echo ""
+
+        echo "> **Note:** 複数担当者がアサインされたアイテムは、各担当者に同一工数が計上されます。担当者別の合計は全体合計と一致しない場合があります。"
+        echo ""
+
+        # Mermaid 円グラフ
+        local has_actual
+        has_actual=$(echo "${ASSIGNEE_EFFORT}" | jq '[.[] | select(.actual_hours > 0)] | length')
+        if [[ "${has_actual}" -gt 0 ]]; then
+          echo '```mermaid'
+          echo 'pie title 担当者別実績工数'
+          echo "${ASSIGNEE_EFFORT}" | jq -r '.[] | select(.actual_hours > 0) | "    \"\(.assignee)\" : \(.actual_hours)"'
+          echo '```'
+          echo ""
+        fi
       fi
     fi
 
@@ -435,13 +461,19 @@ format_effort_markdown() {
 
     # 乖離アイテム
     if [[ "${VARIANCE_ITEMS_COUNT}" -gt 0 ]]; then
-      local md_row_filter="${JQ_MD_ESCAPE}"'
-        "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(if (.assignees | length) > 0 then (.assignees | join(", ")) else "-" end) | \(.estimated_hours) | \(.actual_hours) | \(if .variance_rate >= 0 then "+\(.variance_rate)%" else "\(.variance_rate)%" end) |"'
-
       echo "## 乖離アイテム（上位）"
       echo ""
-      echo "| # | タイトル | 担当者 | 見積もり(h) | 実績(h) | 乖離率 |"
-      echo "|---|---|---|---|---|---|"
+      if is_redact_enabled; then
+        local md_row_filter="${JQ_MD_ESCAPE}"'
+          "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(.estimated_hours) | \(.actual_hours) | \(if .variance_rate >= 0 then \"+\(.variance_rate)%\" else \"\(.variance_rate)%\" end) |"'
+        echo "| # | タイトル | 見積もり(h) | 実績(h) | 乖離率 |"
+        echo "|---|---|---|---|---|"
+      else
+        local md_row_filter="${JQ_MD_ESCAPE}"'
+          "| [#\(.number)](\(.url)) | \(.title | md_escape) | \(if (.assignees | length) > 0 then (.assignees | join(\", \")) else \"-\" end) | \(.estimated_hours) | \(.actual_hours) | \(if .variance_rate >= 0 then \"+\(.variance_rate)%\" else \"\(.variance_rate)%\" end) |"'
+        echo "| # | タイトル | 担当者 | 見積もり(h) | 実績(h) | 乖離率 |"
+        echo "|---|---|---|---|---|---|"
+      fi
       echo "${VARIANCE_ITEMS}" | jq -r ".[] | ${md_row_filter}"
       echo ""
     fi
@@ -465,17 +497,23 @@ format_effort_markdown() {
 
     # 工数未入力アイテム
     if [[ "${MISSING_EFFORT_COUNT}" -gt 0 ]]; then
-      local md_row_filter="${JQ_MD_ESCAPE}"'
-        "| \(if .is_done then "**" else "" end)[#\(.number)](\(.url))\(if .is_done then "**" else "" end) | \(if .is_done then "**" else "" end)\(.title | md_escape)\(if .is_done then "**" else "" end) | \(if .is_done then "**" else "" end)\((.status // "-") | md_escape)\(if .is_done then "**" else "" end) | \(if (.assignees | length) > 0 then (.assignees | join(", ") | md_escape) else "-" end) |"'
-
       echo "## 工数未入力アイテム: ${MISSING_EFFORT_COUNT} 件"
       echo ""
       if [[ "${MISSING_EFFORT_DONE_COUNT}" -gt 0 ]]; then
         echo "> **Warning:** Done ステータスで工数未入力のアイテムが ${MISSING_EFFORT_DONE_COUNT} 件あります（太字で表示）。"
         echo ""
       fi
-      echo "| # | タイトル | ステータス | 担当者 |"
-      echo "|---|---|---|---|"
+      if is_redact_enabled; then
+        local md_row_filter="${JQ_MD_ESCAPE}"'
+          "| \(if .is_done then "**" else "" end)[#\(.number)](\(.url))\(if .is_done then "**" else "" end) | \(if .is_done then "**" else "" end)\(.title | md_escape)\(if .is_done then "**" else "" end) | \(if .is_done then "**" else "" end)\((.status // "-") | md_escape)\(if .is_done then "**" else "" end) |"'
+        echo "| # | タイトル | ステータス |"
+        echo "|---|---|---|"
+      else
+        local md_row_filter="${JQ_MD_ESCAPE}"'
+          "| \(if .is_done then "**" else "" end)[#\(.number)](\(.url))\(if .is_done then "**" else "" end) | \(if .is_done then "**" else "" end)\(.title | md_escape)\(if .is_done then "**" else "" end) | \(if .is_done then "**" else "" end)\((.status // "-") | md_escape)\(if .is_done then "**" else "" end) | \(if (.assignees | length) > 0 then (.assignees | join(", ") | md_escape) else "-" end) |"'
+        echo "| # | タイトル | ステータス | 担当者 |"
+        echo "|---|---|---|---|"
+      fi
       echo "${MISSING_EFFORT_ITEMS}" | jq -r ".[] | ${md_row_filter}"
       echo ""
     fi
@@ -484,14 +522,24 @@ format_effort_markdown() {
 
 format_effort_csv() {
   local items="$1"
-  echo "type,number,title,url,state,repository,author,assignees,labels,created_at,updated_at,status,estimated_hours,actual_hours,due_date,planned_start,planned_end,actual_start,actual_end"
-  echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, .author, (.assignees | join("; ")), (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.estimated_hours // "" | tostring), (.actual_hours // "" | tostring), (.due_date // ""), (.planned_start // ""), (.planned_end // ""), (.actual_start // ""), (.actual_end // "")] | @csv'
+  if is_redact_enabled; then
+    echo "type,number,title,url,state,repository,labels,created_at,updated_at,status,due_date"
+    echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.due_date // "")] | @csv'
+  else
+    echo "type,number,title,url,state,repository,author,assignees,labels,created_at,updated_at,status,estimated_hours,actual_hours,due_date,planned_start,planned_end,actual_start,actual_end"
+    echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, .author, (.assignees | join("; ")), (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.estimated_hours // "" | tostring), (.actual_hours // "" | tostring), (.due_date // ""), (.planned_start // ""), (.planned_end // ""), (.actual_start // ""), (.actual_end // "")] | @csv'
+  fi
 }
 
 format_effort_tsv() {
   local items="$1"
-  echo -e "type\tnumber\ttitle\turl\tstate\trepository\tauthor\tassignees\tlabels\tcreated_at\tupdated_at\tstatus\testimated_hours\tactual_hours\tdue_date\tplanned_start\tplanned_end\tactual_start\tactual_end"
-  echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, .author, (.assignees | join("; ")), (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.estimated_hours // "" | tostring), (.actual_hours // "" | tostring), (.due_date // ""), (.planned_start // ""), (.planned_end // ""), (.actual_start // ""), (.actual_end // "")] | @tsv'
+  if is_redact_enabled; then
+    echo -e "type\tnumber\ttitle\turl\tstate\trepository\tlabels\tcreated_at\tupdated_at\tstatus\tdue_date"
+    echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.due_date // "")] | @tsv'
+  else
+    echo -e "type\tnumber\ttitle\turl\tstate\trepository\tauthor\tassignees\tlabels\tcreated_at\tupdated_at\tstatus\testimated_hours\tactual_hours\tdue_date\tplanned_start\tplanned_end\tactual_start\tactual_end"
+    echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, .author, (.assignees | join("; ")), (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.estimated_hours // "" | tostring), (.actual_hours // "" | tostring), (.due_date // ""), (.planned_start // ""), (.planned_end // ""), (.actual_start // ""), (.actual_end // "")] | @tsv'
+  fi
 }
 
 # --- レポート出力 ---
@@ -542,6 +590,14 @@ case "${OUTPUT_FORMAT}" in
         missing_effort_items: $missing_effort_items
       }
     ')
+    if is_redact_enabled; then
+      REPORT_JSON=$(echo "${REPORT_JSON}" | jq '
+        del(.by_assignee) |
+        .variance_items = [.variance_items[] | del(.author, .assignees)] |
+        .lead_time = [.lead_time[] | del(.assignees)] |
+        .missing_effort_items = [.missing_effort_items[] | del(.assignees)]
+      ')
+    fi
     echo "${REPORT_JSON}" > "${OUTPUT_FILE}"
     ;;
   markdown)

--- a/scripts/generate-summary-report.sh
+++ b/scripts/generate-summary-report.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 #   PROJECT_NUMBER - 対象 Project の Number
 #   ITEM_TYPE      - 対象アイテムの種別（all / issues / prs、デフォルト: all）
 #   ITEM_STATE     - 対象アイテムの状態（open / closed / all、デフォルト: all）
-#   OUTPUT_FORMAT  - 出力形式（json / markdown / csv / tsv、デフォルト: json）
+#   OUTPUT_FORMAT     - 出力形式（json / markdown / csv / tsv、デフォルト: json）
+#   REDACT_SENSITIVE  - 機密フィールドをリダクション（true / false、デフォルト: false）
 
 # --- 共通ライブラリ読み込み ---
 
@@ -29,6 +30,7 @@ validate_enum "ITEM_TYPE" "${ITEM_TYPE}" "all" "issues" "prs"
 validate_enum "ITEM_STATE" "${ITEM_STATE}" "open" "closed" "all"
 OUTPUT_FORMAT="${OUTPUT_FORMAT:-json}"
 validate_enum "OUTPUT_FORMAT" "${OUTPUT_FORMAT}" "markdown" "csv" "tsv" "json"
+REDACT_SENSITIVE="${REDACT_SENSITIVE:-false}"
 
 # --- ヘルパー関数 ---
 
@@ -181,6 +183,13 @@ ITEMS=$(echo "${ITEMS}" | filter_items_by_state)
 TOTAL_COUNT=$(echo "${ITEMS}" | jq 'length')
 echo "  合計: ${TOTAL_COUNT} 件（フィルタ後）"
 
+# --- 機密フィールドのリダクション ---
+
+if is_redact_enabled; then
+  echo "  機密フィールドをリダクションしています..."
+  ITEMS=$(echo "${ITEMS}" | jq '[.[] | .author = "***" | .assignees = ["***"]]')
+fi
+
 # --- 基本集計 ---
 
 echo ""
@@ -220,17 +229,21 @@ STATUS_SUMMARY=$(echo "${ITEMS}" | jq --argjson total "${TOTAL_COUNT}" '
 ')
 
 # 担当者別集計
-ASSIGNEE_SUMMARY=$(echo "${ITEMS}" | jq '
-  [.[] | . as $item | (if (.assignees | length) == 0 then ["(未アサイン)"] else .assignees end)[] | {assignee: ., status: $item.status}]
-  | sort_by(.assignee) | group_by(.assignee)
-  | map({
-      assignee: .[0].assignee,
-      total: length,
-      in_progress: ([.[] | select(.status == "In Progress")] | length),
-      in_review: ([.[] | select(.status == "In Review")] | length)
-    })
-  | sort_by(-.total)
-')
+if is_redact_enabled; then
+  ASSIGNEE_SUMMARY="[]"
+else
+  ASSIGNEE_SUMMARY=$(echo "${ITEMS}" | jq '
+    [.[] | . as $item | (if (.assignees | length) == 0 then ["(未アサイン)"] else .assignees end)[] | {assignee: ., status: $item.status}]
+    | sort_by(.assignee) | group_by(.assignee)
+    | map({
+        assignee: .[0].assignee,
+        total: length,
+        in_progress: ([.[] | select(.status == "In Progress")] | length),
+        in_review: ([.[] | select(.status == "In Review")] | length)
+      })
+    | sort_by(-.total)
+  ')
+fi
 
 # ラベル別集計
 LABEL_SUMMARY=$(echo "${ITEMS}" | jq '
@@ -332,12 +345,14 @@ format_summary_markdown() {
     fi
 
     # 担当者別
-    echo "## 担当者別"
-    echo ""
-    echo "| 担当者 | 件数 | In Progress | In Review |"
-    echo "|---|---|---|---|"
-    echo "${ASSIGNEE_SUMMARY}" | jq -r '.[] | "| \(.assignee) | \(.total) | \(.in_progress) | \(.in_review) |"'
-    echo ""
+    if ! is_redact_enabled; then
+      echo "## 担当者別"
+      echo ""
+      echo "| 担当者 | 件数 | In Progress | In Review |"
+      echo "|---|---|---|---|"
+      echo "${ASSIGNEE_SUMMARY}" | jq -r '.[] | "| \(.assignee) | \(.total) | \(.in_progress) | \(.in_review) |"'
+      echo ""
+    fi
 
     # ラベル別
     echo "## ラベル別"
@@ -360,13 +375,19 @@ format_summary_markdown() {
 
     # 期日超過アイテム
     if [[ "${HAS_DUE_DATE}" == "true" && "${OVERDUE_COUNT}" -gt 0 ]]; then
-      local md_row_filter="${JQ_MD_ESCAPE}"'
-        "| [#\(.number)](\(.url)) | \(.title | md_escape) | \((.status // \"-\") | md_escape) | \(if (.assignees | length) > 0 then (.assignees | join(\", \") | md_escape) else \"-\" end) | \(.due_date) | \(.days_overdue) |"'
-
       echo "## 期日超過アイテム: ${OVERDUE_COUNT} 件"
       echo ""
-      echo "| # | タイトル | ステータス | 担当者 | 終了期日 | 超過日数 |"
-      echo "|---|---------|-----------|--------|---------|---------|"
+      if is_redact_enabled; then
+        local md_row_filter="${JQ_MD_ESCAPE}"'
+          "| [#\(.number)](\(.url)) | \(.title | md_escape) | \((.status // \"-\") | md_escape) | \(.due_date) | \(.days_overdue) |"'
+        echo "| # | タイトル | ステータス | 終了期日 | 超過日数 |"
+        echo "|---|---------|-----------|---------|---------|"
+      else
+        local md_row_filter="${JQ_MD_ESCAPE}"'
+          "| [#\(.number)](\(.url)) | \(.title | md_escape) | \((.status // \"-\") | md_escape) | \(if (.assignees | length) > 0 then (.assignees | join(\", \") | md_escape) else \"-\" end) | \(.due_date) | \(.days_overdue) |"'
+        echo "| # | タイトル | ステータス | 担当者 | 終了期日 | 超過日数 |"
+        echo "|---|---------|-----------|--------|---------|---------|"
+      fi
       echo "${OVERDUE_ITEMS}" | jq -r ".[] | ${md_row_filter}"
       echo ""
     fi
@@ -375,14 +396,24 @@ format_summary_markdown() {
 
 format_summary_csv() {
   local items="$1"
-  echo "type,number,title,url,state,repository,author,assignees,labels,created_at,updated_at,status,estimated_hours,actual_hours,due_date"
-  echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, .author, (.assignees | join("; ")), (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.estimated_hours // "" | tostring), (.actual_hours // "" | tostring), (.due_date // "")] | @csv'
+  if is_redact_enabled; then
+    echo "type,number,title,url,state,repository,labels,created_at,updated_at,status,due_date"
+    echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.due_date // "")] | @csv'
+  else
+    echo "type,number,title,url,state,repository,author,assignees,labels,created_at,updated_at,status,estimated_hours,actual_hours,due_date"
+    echo "${items}" | jq -r '.[] | [.type, .number, .title, .url, .state, .repository, .author, (.assignees | join("; ")), (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.estimated_hours // "" | tostring), (.actual_hours // "" | tostring), (.due_date // "")] | @csv'
+  fi
 }
 
 format_summary_tsv() {
   local items="$1"
-  echo -e "type\tnumber\ttitle\turl\tstate\trepository\tauthor\tassignees\tlabels\tcreated_at\tupdated_at\tstatus\testimated_hours\tactual_hours\tdue_date"
-  echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, .author, (.assignees | join("; ")), (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.estimated_hours // "" | tostring), (.actual_hours // "" | tostring), (.due_date // "")] | @tsv'
+  if is_redact_enabled; then
+    echo -e "type\tnumber\ttitle\turl\tstate\trepository\tlabels\tcreated_at\tupdated_at\tstatus\tdue_date"
+    echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.due_date // "")] | @tsv'
+  else
+    echo -e "type\tnumber\ttitle\turl\tstate\trepository\tauthor\tassignees\tlabels\tcreated_at\tupdated_at\tstatus\testimated_hours\tactual_hours\tdue_date"
+    echo "${items}" | jq -r '.[] | [.type, (.number | tostring), .title, .url, .state, .repository, .author, (.assignees | join("; ")), (.labels | join("; ")), .created_at, .updated_at, (.status // ""), (.estimated_hours // "" | tostring), (.actual_hours // "" | tostring), (.due_date // "")] | @tsv'
+  fi
 }
 
 # --- レポート出力 ---
@@ -448,6 +479,11 @@ case "${OUTPUT_FORMAT}" in
           }
         }
       ')
+    fi
+
+    # リダクション: 機密フィールドを除外
+    if is_redact_enabled; then
+      REPORT_JSON=$(echo "${REPORT_JSON}" | jq 'del(.by_assignee) | del(.effort) | .overdue_items = [.overdue_items[] | del(.author, .assignees)]')
     fi
 
     echo "${REPORT_JSON}" > "${OUTPUT_FILE}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -317,6 +317,12 @@ get_file_extension() {
   esac
 }
 
+# REDACT_SENSITIVE が有効かどうかを判定する
+# 使用例: if is_redact_enabled; then ... fi
+is_redact_enabled() {
+  [[ "${REDACT_SENSITIVE:-false}" == "true" ]]
+}
+
 # 環境変数の値が許可リストに含まれるかチェックする
 # 使用例: validate_enum "OUTPUT_FORMAT" "${OUTPUT_FORMAT}" "markdown" "csv" "tsv" "json"
 validate_enum() {


### PR DESCRIPTION
## Summary

- レポート生成スクリプト4本（summary, effort, stale, export）に `REDACT_SENSITIVE` 環境変数による機密フィールド除外機能を追加
- ワークフロー `05-analyze-project.yml` に `redact_sensitive` 入力パラメータを追加
- ドキュメント `docs/workflows/05-analyze-project.md` にリダクション機能の説明を追加

## 変更内容

### 共通（`scripts/lib/common.sh`）
- `is_redact_enabled` ヘルパー関数を追加

### 各スクリプト共通
- `REDACT_SENSITIVE` 環境変数のサポート（デフォルト: `false`）
- `true` 設定時に以下を除外:
  - **担当者名**（`assignees`）: 全レポートで除外
  - **作成者名**（`author`）: summary, effort, export で除外
  - **担当者別集計セクション**: summary, effort で非表示
  - **工数・スケジュール**: CSV/TSV のフラットデータから除外
- 全出力形式（JSON, Markdown, CSV, TSV）でリダクション対応

### ワークフロー
- `redact_sensitive` boolean 入力パラメータを追加（全4ジョブに環境変数として伝播）

## Test plan

- [ ] `REDACT_SENSITIVE=false`（デフォルト）で既存の動作に影響がないことを確認
- [ ] `REDACT_SENSITIVE=true` で各レポートから担当者名・作成者名が除外されることを確認
- [ ] 各出力形式（JSON, Markdown, CSV, TSV）でリダクションが正しく動作することを確認
- [ ] ワークフローの `redact_sensitive` パラメータがスクリプトに正しく伝播されることを確認

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)