### PR TITLE
fix: 05-analyze-project.yml の choice パラメータを required: true に変更

### DIFF
--- a/.github/workflows/05-analyze-project.yml
+++ b/.github/workflows/05-analyze-project.yml
@@ -9,7 +9,7 @@ on:
         type: number
       report_types:
         description: "実行するレポート/機能タイプ（all: 全機能, stale: 滞留検知, summary: サマリー, effort: 工数集計, export: アイテムエクスポート）"
-        required: false
+        required: true
         type: choice
         default: "all"
         options:
@@ -20,7 +20,7 @@ on:
           - export
       output_format:
         description: "出力形式"
-        required: false
+        required: true
         type: choice
         default: "json"
         options:
@@ -30,7 +30,7 @@ on:
           - tsv
       item_type:
         description: "対象アイテムの種別"
-        required: false
+        required: true
         type: choice
         default: "all"
         options:
@@ -39,7 +39,7 @@ on:
           - prs
       item_state:
         description: "対象アイテムの状態（open / closed / all）"
-        required: false
+        required: true
         type: choice
         default: "all"
         options:

--- a/docs/workflows/05-analyze-project.md
+++ b/docs/workflows/05-analyze-project.md
@@ -24,10 +24,10 @@
 | パラメータ | 説明 | 必須 | タイプ | デフォルト | 例 |
 |------------|------|:----:|--------|-----------|-----|
 | `project_number` | 対象 `Project` の Number | ✅ | `number` | — | `1` |
-| `report_types` | 実行する機能 | — | `choice` | `all` | `stale` |
-| `output_format` | 出力形式 | — | `choice` | `json` | `markdown` |
-| `item_type` | 対象アイテムの種別 | — | `choice` | `all` | `issues` |
-| `item_state` | 対象アイテムの状態 | — | `choice` | `all` | `open` |
+| `report_types` | 実行する機能 | ✅ | `choice` | `all` | `stale` |
+| `output_format` | 出力形式 | ✅ | `choice` | `json` | `markdown` |
+| `item_type` | 対象アイテムの種別 | ✅ | `choice` | `all` | `issues` |
+| `item_state` | 対象アイテムの状態 | ✅ | `choice` | `all` | `open` |
 | `retention_days` | アーティファクトの保持日数（1〜7） | ✅ | `number` | `7` | `3` |
 
 ### `report_types` の選択肢


### PR DESCRIPTION
## Summary
- `05-analyze-project.yml` の choice 型パラメータ4件（`report_types`, `output_format`, `item_type`, `item_state`）を `required: true` に変更
- `docs/workflows/05-analyze-project.md` のパラメータテーブルの必須列を更新

## Test plan
- [ ] ワークフローの `Run workflow` 画面で全パラメータが必須表示されることを確認
- [ ] デフォルト値のままワークフローが正常に実行できることを確認

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)