### PR TITLE
fix: 依頼元フィールドの dataType を Text → TEXT に修正（#269）

### DIFF
--- a/scripts/config/project-field-definitions.json
+++ b/scripts/config/project-field-definitions.json
@@ -29,6 +29,6 @@
   },
   {
     "name": "依頼元",
-    "dataType": "Text"
+    "dataType": "TEXT"
   }
 ]


### PR DESCRIPTION
## Summary
- `scripts/config/project-field-definitions.json` の「依頼元」フィールドの `dataType` を `"Text"` → `"TEXT"` に修正
- GitHub Projects API の `ProjectV2CustomFieldType` enum に準拠した正しい値に変更

## Test plan
- [ ] ワークフロー ② を実行し、「依頼元」フィールドが正常に作成されることを確認

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)