### PR TITLE
fix: ワークフローのstring型インプットに対して前後の空白トリムを追加

### DIFF
--- a/.github/workflows/01-create-project.yml
+++ b/.github/workflows/01-create-project.yml
@@ -39,8 +39,8 @@ jobs:
           PROJECT_TITLE: ${{ inputs.project_title }}
           PROJECT_VISIBILITY: ${{ inputs.visibility }}
         run: |
-          # トリム
-          PROJECT_TITLE="$(echo "$PROJECT_TITLE" | xargs)"
+          # トリム（前後の空白のみ削除、内部空白は保持）
+          PROJECT_TITLE="$(echo "$PROJECT_TITLE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           chmod +x scripts/setup-github-project.sh
           bash scripts/setup-github-project.sh
 

--- a/.github/workflows/03-setup-repository-labels.yml
+++ b/.github/workflows/03-setup-repository-labels.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: ラベルを一括作成
         run: |
-          # トリム
-          TARGET_REPO="$(echo "$TARGET_REPO" | xargs)"
+          # トリム（前後の空白のみ削除、内部空白は保持）
+          TARGET_REPO="$(echo "$TARGET_REPO" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           chmod +x scripts/setup-repository-labels.sh
           bash scripts/setup-repository-labels.sh
 

--- a/.github/workflows/04-add-items-to-project.yml
+++ b/.github/workflows/04-add-items-to-project.yml
@@ -57,9 +57,9 @@ jobs:
           ITEM_STATE: ${{ inputs.item_state }}
           ITEM_LABEL: ${{ inputs.item_label }}
         run: |
-          # トリム
-          TARGET_REPO="$(echo "$TARGET_REPO" | xargs)"
-          ITEM_LABEL="$(echo "$ITEM_LABEL" | xargs)"
+          # トリム（前後の空白のみ削除、内部空白は保持）
+          TARGET_REPO="$(echo "$TARGET_REPO" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          ITEM_LABEL="$(echo "$ITEM_LABEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           chmod +x scripts/add-items-to-project.sh
           bash scripts/add-items-to-project.sh
 


### PR DESCRIPTION
## Summary
- `workflow_dispatch` の `type: string` インプットに対し、`run:` ブロック冒頭で `xargs` によるトリム処理を追加
- 対象: `01-create-project.yml`（`PROJECT_TITLE`）、`03-setup-repository-labels.yml`（`TARGET_REPO`）、`04-add-items-to-project.yml`（`TARGET_REPO`, `ITEM_LABEL`）

## Test plan
- [ ] 各ワークフローを手動実行し、前後に空白を含む入力値が正しくトリムされることを確認
- [ ] 空白なしの通常入力で既存動作に影響がないことを確認

close #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)