### PR TITLE
feat: ラベル定義を見直し・拡充（#278）

### DIFF
--- a/docs/scripts/setup-repository-labels.md
+++ b/docs/scripts/setup-repository-labels.md
@@ -55,6 +55,56 @@
     "name": "documentation",
     "color": "0075ca",
     "description": "ドキュメントの追加・更新"
+  },
+  {
+    "name": "on-hold",
+    "color": "c2e0c6",
+    "description": "保留中"
+  },
+  {
+    "name": "blocked",
+    "color": "e4e669",
+    "description": "ブロック中"
+  },
+  {
+    "name": "duplicate",
+    "color": "cfd3d7",
+    "description": "重複する Issue/PR"
+  },
+  {
+    "name": "invalid",
+    "color": "e4e669",
+    "description": "無効な Issue/PR"
+  },
+  {
+    "name": "wontfix",
+    "color": "ffffff",
+    "description": "対応しない Issue/PR"
+  },
+  {
+    "name": "question",
+    "color": "d876e3",
+    "description": "質問・確認事項"
+  },
+  {
+    "name": "good first issue",
+    "color": "7057ff",
+    "description": "初めてのコントリビューター向け"
+  },
+  {
+    "name": "help wanted",
+    "color": "008672",
+    "description": "協力を求めている Issue"
+  },
+  {
+    "name": "priority: high",
+    "color": "b60205",
+    "description": "優先度：高"
+  },
+  {
+    "name": "priority: low",
+    "color": "0e8a16",
+    "description": "優先度：低"
   }
 ]
 ```

--- a/scripts/config/repository-label-definitions.json
+++ b/scripts/config/repository-label-definitions.json
@@ -13,5 +13,55 @@
     "name": "documentation",
     "color": "0075ca",
     "description": "ドキュメントの追加・更新"
+  },
+  {
+    "name": "on-hold",
+    "color": "c2e0c6",
+    "description": "保留中"
+  },
+  {
+    "name": "blocked",
+    "color": "e4e669",
+    "description": "ブロック中"
+  },
+  {
+    "name": "duplicate",
+    "color": "cfd3d7",
+    "description": "重複する Issue/PR"
+  },
+  {
+    "name": "invalid",
+    "color": "e4e669",
+    "description": "無効な Issue/PR"
+  },
+  {
+    "name": "wontfix",
+    "color": "ffffff",
+    "description": "対応しない Issue/PR"
+  },
+  {
+    "name": "question",
+    "color": "d876e3",
+    "description": "質問・確認事項"
+  },
+  {
+    "name": "good first issue",
+    "color": "7057ff",
+    "description": "初めてのコントリビューター向け"
+  },
+  {
+    "name": "help wanted",
+    "color": "008672",
+    "description": "協力を求めている Issue"
+  },
+  {
+    "name": "priority: high",
+    "color": "b60205",
+    "description": "優先度：高"
+  },
+  {
+    "name": "priority: low",
+    "color": "0e8a16",
+    "description": "優先度：低"
   }
 ]


### PR DESCRIPTION
## Summary
- `scripts/config/repository-label-definitions.json` に10件のラベルを追加
  - **スクリプト整合性（必須）**: `on-hold`, `blocked` — `detect-stale-items.sh` の `EXCLUDE_LABELS` で参照されているラベル
  - **GitHub 標準ラベル（推奨）**: `duplicate`, `invalid`, `wontfix`, `question`, `good first issue`, `help wanted`
  - **プロジェクト運用向け（任意）**: `priority: high`, `priority: low`
- `docs/scripts/setup-repository-labels.md` の定義例を更新後のラベル定義と同期

## Test plan
- [ ] `repository-label-definitions.json` が有効な JSON であること
- [ ] 既存の3件のラベル定義が変更されていないこと
- [ ] 追加された10件のラベルの name, color, description が Issue の仕様と一致すること
- [ ] ドキュメントの定義例が JSON ファイルと一致すること

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)