### PR TITLE
docs: 用語集を細分化し Git 用語・GitHub Repository 関連用語を追加（#283）

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,9 +4,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [🔀 Git 基本用語](#-git-%E5%9F%BA%E6%9C%AC%E7%94%A8%E8%AA%9E)
-- [📦 GitHub Repository 関連用語](#-github-repository-%E9%96%A2%E9%80%A3%E7%94%A8%E8%AA%9E)
-- [👥 GitHub 組織・アカウント用語](#-github-%E7%B5%84%E7%B9%94%E3%83%BB%E3%82%A2%E3%82%AB%E3%82%A6%E3%83%B3%E3%83%88%E7%94%A8%E8%AA%9E)
+- [📘 GitHub 基本用語](#-github-%E5%9F%BA%E6%9C%AC%E7%94%A8%E8%AA%9E)
 - [📋 GitHub Projects 関連用語](#-github-projects-%E9%96%A2%E9%80%A3%E7%94%A8%E8%AA%9E)
 - [🔑 認証・トークン関連用語](#-%E8%AA%8D%E8%A8%BC%E3%83%BB%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E9%96%A2%E9%80%A3%E7%94%A8%E8%AA%9E)
 - [⚡ GitHub Actions 関連用語](#-github-actions-%E9%96%A2%E9%80%A3%E7%94%A8%E8%AA%9E)


### PR DESCRIPTION
## Summary

- 「📘 GitHub 基本用語」を「🔀 Git 基本用語」「📦 GitHub Repository 関連用語」「👥 GitHub 組織・アカウント用語」の3カテゴリに分割・再構成
- Git 用語（Clone, Commit, Push, Pull, Tag）と GitHub Repository 用語（Label, Milestone）を新規追加
- `owner` / `owner/repo 形式` を「その他の用語」から「GitHub 組織・アカウント用語」に移動

## Test plan

- [ ] 目次（TOC）のリンクが正しく動作すること
- [ ] 各セクションの用語が適切なカテゴリに分類されていること
- [ ] 新規追加した用語の説明が正確であること

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)