### PR TITLE
fix: add-items-to-project.sh に ITEM_STATE のバリデーションを追加

### DIFF
--- a/scripts/add-items-to-project.sh
+++ b/scripts/add-items-to-project.sh
@@ -33,6 +33,7 @@ ITEM_STATE="${ITEM_STATE:-open}"
 ITEM_LABEL="${ITEM_LABEL:-}"
 
 validate_enum "ITEM_TYPE" "${ITEM_TYPE}" "all" "issues" "prs"
+validate_enum "ITEM_STATE" "${ITEM_STATE}" "open" "closed" "all"
 
 # ステータス自動付与ルール: open → Backlog、closed/merged → Done
 INITIAL_STATUS="Backlog"


### PR DESCRIPTION
## Summary
- `add-items-to-project.sh` で `ITEM_STATE` 環境変数に `validate_enum` バリデーションを追加
- 不正な値（`open` / `closed` / `all` 以外）が渡された場合にエラーメッセージを出力して終了するようにした

## Test plan
- [ ] `ITEM_STATE=invalid` で実行し、エラーメッセージが表示されることを確認
- [ ] `ITEM_STATE=open` / `closed` / `all` で正常に動作することを確認
- [ ] `ITEM_STATE` 未指定時にデフォルト値 `open` で正常に動作することを確認

close #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)