### PR TITLE
fix: jq の // 演算子をオブジェクト構築内で括弧によりグルーピング

### DIFF
--- a/scripts/generate-summary-report.sh
+++ b/scripts/generate-summary-report.sh
@@ -148,7 +148,7 @@ read -r OPEN_COUNT CLOSED_COUNT MERGED_COUNT < <(echo "${ITEMS}" | jq -r '[
 STATUS_SUMMARY=$(echo "${ITEMS}" | jq --argjson total "${TOTAL_COUNT}" "${JQ_STATUS_ORDER}"'
   sort_by(.status // "(未設定)") | group_by(.status // "(未設定)")
   | map({
-      status: .[0].status // "(未設定)",
+      status: (.[0].status // "(未設定)"),
       count: length,
       percentage: (if $total > 0 then (length / $total * 1000 | round / 10) else 0 end)
     })
@@ -187,7 +187,7 @@ if [[ "${HAS_EFFORT}" == "true" ]]; then
   EFFORT_SUMMARY=$(echo "${ITEMS}" | jq "${JQ_STATUS_ORDER}"'
     sort_by(.status // "(未設定)") | group_by(.status // "(未設定)")
     | map({
-        status: .[0].status // "(未設定)",
+        status: (.[0].status // "(未設定)"),
         estimated_hours: ([.[] | .estimated_hours // 0] | add),
         actual_hours: ([.[] | .actual_hours // 0] | add)
       })


### PR DESCRIPTION
## Summary
- `scripts/generate-summary-report.sh` 内の jq オブジェクト構築 `{}` で `//` 演算子を使用している2箇所に括弧を追加し、シンタックスエラーを解消

## 修正箇所
- 151行目: ステータス別集計の `status` フィールド
- 190行目: 工数サマリーの `status` フィールド

## Test plan
- [ ] ワークフロー⑤（統合プロジェクト分析）を実行し、jq シンタックスエラーが発生しないことを確認
- [ ] レポート出力内容が正しいことを確認

close #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)