### PR TITLE
fix: jq の // 演算子をオブジェクト構築内で括弧によりグルーピング

### DIFF
--- a/scripts/generate-effort-report.sh
+++ b/scripts/generate-effort-report.sh
@@ -197,7 +197,7 @@ STATUS_EFFORT=$(echo "${ITEMS}" | jq --argjson total_estimated "${TOTAL_ESTIMATE
   [.[] | select(.estimated_hours != null or .actual_hours != null)]
   | sort_by(.status // "(未設定)") | group_by(.status // "(未設定)")
   | map({
-      status: .[0].status // "(未設定)",
+      status: (.[0].status // "(未設定)"),
       count: length,
       estimated_hours: ([.[].estimated_hours // 0] | add),
       actual_hours: ([.[].actual_hours // 0] | add)


### PR DESCRIPTION
## Summary
- `scripts/generate-effort-report.sh` のステータス別工数集計処理で、jq のオブジェクト構築 `{}` 内の `//` 演算子を括弧でグルーピングし、シンタックスエラーを解消

## 対応内容
- 200行目: `status: .[0].status // "(未設定)"` → `status: (.[0].status // "(未設定)")` に修正

## Test plan
- [ ] ワークフロー「⑤ 統合プロジェクト分析」が正常に完了することを確認

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)