### PR TITLE
fix: jq に -r フラグを追加して日付パースエラーを修正

### DIFF
--- a/scripts/generate-velocity-report.sh
+++ b/scripts/generate-velocity-report.sh
@@ -128,7 +128,7 @@ EXECUTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # 集計期間の開始日を計算（現在の ISO 週の月曜日から VELOCITY_WEEKS 週前）
 # macOS と Linux の date 互換性のため jq で計算
-read -r PERIOD_START PERIOD_END < <(jq -n \
+read -r PERIOD_START PERIOD_END < <(jq -rn \
   --argjson weeks "${VELOCITY_WEEKS}" '
   (now | floor) as $now |
   # 現在の曜日（月=0, 日=6）


### PR DESCRIPTION
## Summary
- `scripts/generate-velocity-report.sh` 131行目の `jq` コマンドに `-r` (raw output) フラグを追加
- `@tsv` 出力がダブルクォート囲みとなり `tr` によるタブ分割が機能しない問題を修正

## 原因
`jq -n` では `@tsv` の出力が JSON 文字列（`"2026-01-26\t2026-03-22"`）となり、リテラルなタブ文字が含まれないため `tr '\t' ' '` が動作せず、`PERIOD_START` に全体が格納されて日付パースエラーが発生していた。

## 修正内容
`jq -n` → `jq -rn` に変更し、raw output でタブ文字が正しく出力されるようにした。

## Test plan
- [ ] `⑤ 統合プロジェクト分析` ワークフローを実行し、ベロシティ集計が正常に完了することを確認

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)