### PR TITLE
docs: PRs Welcome バッジを削除し、Issues/Discussions Welcome バッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 [![GitHub Stars](https://img.shields.io/github/stars/mabubu0203/github-projects-starter-kit)](https://github.com/mabubu0203/github-projects-starter-kit/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/mabubu0203/github-projects-starter-kit)](https://github.com/mabubu0203/github-projects-starter-kit/forks)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/mabubu0203/github-projects-starter-kit)](https://github.com/mabubu0203/github-projects-starter-kit/commits)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/mabubu0203/github-projects-starter-kit/pulls)
+[![Issues Welcome](https://img.shields.io/badge/Issues-welcome-brightgreen)](https://github.com/mabubu0203/github-projects-starter-kit/issues)
+[![Discussions Welcome](https://img.shields.io/badge/Discussions-welcome-brightgreen)](https://github.com/mabubu0203/github-projects-starter-kit/discussions)
   
 [![TOC Generator](https://github.com/mabubu0203/github-projects-starter-kit/actions/workflows/toc.yml/badge.svg)](https://github.com/mabubu0203/github-projects-starter-kit/actions/workflows/toc.yml)
 [![Pages Deploy](https://github.com/mabubu0203/github-projects-starter-kit/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/mabubu0203/github-projects-starter-kit/actions/workflows/pages/pages-build-deployment)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,8 @@
 
 [![GitHub Stars](https://img.shields.io/github/stars/mabubu0203/github-projects-starter-kit)](https://github.com/mabubu0203/github-projects-starter-kit/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/mabubu0203/github-projects-starter-kit)](https://github.com/mabubu0203/github-projects-starter-kit/forks)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/mabubu0203/github-projects-starter-kit/pulls)
+[![Issues Welcome](https://img.shields.io/badge/Issues-welcome-brightgreen)](https://github.com/mabubu0203/github-projects-starter-kit/issues)
+[![Discussions Welcome](https://img.shields.io/badge/Discussions-welcome-brightgreen)](https://github.com/mabubu0203/github-projects-starter-kit/discussions)
 
 GitHub Projects の初期セットアップを GitHub Actions で自動実行するための **スターターキット** です。
 


### PR DESCRIPTION
## Summary
- README.md および docs/index.md から PRs Welcome バッジを削除
- Issues Welcome バッジを追加（Issues タブへリンク）
- Discussions Welcome バッジを追加（Discussions タブへリンク）

## 背景
本リポジトリでは外部からの PR は望んでいないため、PRs Welcome バッジは誤ったメッセージを伝えてしまう。代わりに Issue や Discussion での参加を歓迎する方針に合わせた。

closes #313

## Test plan
- [ ] README.md のバッジが正しく表示されること
- [ ] docs/index.md のバッジが正しく表示されること
- [ ] Issues Welcome バッジが Issues タブにリンクすること
- [ ] Discussions Welcome バッジが Discussions タブにリンクすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)