### PR TITLE
docs: インデックスページの目次挿入位置をタイトル・概要の下に移動

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,3 +1,7 @@
+# 🚀 はじめに
+
+GitHub Projects Ops Kit を使い始めるためのクイックスタートガイドです。お好みの方法でセットアップを進めてください。
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -6,10 +10,6 @@
 </ul></details>
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# 🚀 はじめに
-
-GitHub Projects Ops Kit を使い始めるためのクイックスタートガイドです。お好みの方法でセットアップを進めてください。
 
 ## ページ一覧
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,3 +1,7 @@
+# 📏 運用ガイド
+
+GitHub Projects Ops Kit を導入した後の運用に役立つガイドです。カンバンルール・Label 運用・認証設定などを解説しています。
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -6,10 +10,6 @@
 </ul></details>
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# 📏 運用ガイド
-
-GitHub Projects Ops Kit を導入した後の運用に役立つガイドです。カンバンルール・Label 運用・認証設定などを解説しています。
 
 ## ページ一覧
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,7 @@
+# 📚 開発者向け
+
+用語集、内部構成、プロジェクトの背景情報など、開発者やコントリビューター向けの情報です。
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -6,10 +10,6 @@
 </ul></details>
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# 📚 開発者向け
-
-用語集、内部構成、プロジェクトの背景情報など、開発者やコントリビューター向けの情報です。
 
 ## ページ一覧
 

--- a/docs/scripts/index.md
+++ b/docs/scripts/index.md
@@ -1,3 +1,7 @@
+# 📜 スクリプトリファレンス
+
+各 Bash スクリプトの仕様・パラメータ・使用方法の詳細ドキュメントです。Workflow をカスタマイズしたい方や開発者向けの情報です。
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -6,10 +10,6 @@
 </ul></details>
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# 📜 スクリプトリファレンス
-
-各 Bash スクリプトの仕様・パラメータ・使用方法の詳細ドキュメントです。Workflow をカスタマイズしたい方や開発者向けの情報です。
 
 ## ページ一覧
 

--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -1,3 +1,7 @@
+# 🔧 FAQ・トラブルシューティング
+
+困ったときやエラーが発生したときに参照するページです。
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -6,10 +10,6 @@
 </ul></details>
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# 🔧 FAQ・トラブルシューティング
-
-困ったときやエラーが発生したときに参照するページです。
 
 ## ページ一覧
 

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -1,3 +1,7 @@
+# 🧭 ユースケース
+
+あなたの立場やチーム規模に合わせた活用ガイドです。導入を検討している方は、自分に近いケースを参考にしてください。
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -6,10 +10,6 @@
 </ul></details>
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# 🧭 ユースケース
-
-あなたの立場やチーム規模に合わせた活用ガイドです。導入を検討している方は、自分に近いケースを参考にしてください。
 
 ## ページ一覧
 

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -1,3 +1,7 @@
+# ⚙️ Workflow リファレンス
+
+GitHub Actions の `workflow_dispatch` で実行する各 Workflow の詳細ドキュメントです。番号順に実行することを推奨します。
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -6,10 +10,6 @@
 </ul></details>
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# ⚙️ Workflow リファレンス
-
-GitHub Actions の `workflow_dispatch` で実行する各 Workflow の詳細ドキュメントです。番号順に実行することを推奨します。
 
 ## ページ一覧
 


### PR DESCRIPTION
## Summary
- `docs/` 配下の全7カテゴリインデックスページで、doctoc 目次ブロックをファイル先頭からタイトル・概要文の下に移動
- 他のドキュメントファイル（`quickstart-gui.md` 等）と「タイトル → 概要 → 目次」の順序を統一

## Test plan
- [ ] 各インデックスページで目次がタイトル・概要の下に表示されることを確認
- [ ] doctoc の自動更新が正しく動作することを確認

close #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)