### PR TITLE
refactor: setup-repository-health-files の対象ファイル定義を JSON 化

### DIFF
--- a/docs/scripts/setup-repository-health-files.md
+++ b/docs/scripts/setup-repository-health-files.md
@@ -33,6 +33,7 @@
 ## 📋 対象ファイル
 
 以下の Community Health Files を空ファイルとして登録します。
+対象ファイルは `scripts/config/health-file-definitions.json` で定義されており、ユーザーがスクリプトを直接編集せずにカスタマイズできます。
 
 | ファイル | パス | 説明 |
 |----------|------|------|
@@ -45,6 +46,24 @@
 | Issue テンプレート設定 | `.github/ISSUE_TEMPLATE/config.yml` | Issue テンプレートの設定ファイル |
 
 > **Note:** `FUNDING.yml` は対象外です。
+
+### 設定ファイルのカスタマイズ
+
+`scripts/config/health-file-definitions.json` を編集することで、登録対象のファイルを追加・削除できます。
+
+```json
+[
+  {
+    "path": ".github/CODE_OF_CONDUCT.md",
+    "description": "行動規範"
+  }
+]
+```
+
+| フィールド | 説明 | 必須 |
+|------------|------|:----:|
+| `path` | Repository 内のファイルパス | ✅ |
+| `description` | ファイルの説明 | — |
 
 ## 📊 処理フロー
 

--- a/docs/workflows/05-setup-repository-health-files.md
+++ b/docs/workflows/05-setup-repository-health-files.md
@@ -46,6 +46,9 @@
 
 ### 対象ファイル
 
+対象ファイルは [`scripts/config/health-file-definitions.json`](../../scripts/config/health-file-definitions.json) で定義されています。
+JSON ファイルを編集することで、スクリプトを変更せずに登録対象をカスタマイズできます。
+
 | ファイル | パス |
 |----------|------|
 | `CODE_OF_CONDUCT.md` | `.github/CODE_OF_CONDUCT.md` |

--- a/scripts/config/health-file-definitions.json
+++ b/scripts/config/health-file-definitions.json
@@ -1,0 +1,30 @@
+[
+  {
+    "path": ".github/CODE_OF_CONDUCT.md",
+    "description": "行動規範"
+  },
+  {
+    "path": ".github/CONTRIBUTING.md",
+    "description": "コントリビューションガイド"
+  },
+  {
+    "path": ".github/GOVERNANCE.md",
+    "description": "ガバナンスポリシー"
+  },
+  {
+    "path": ".github/SECURITY.md",
+    "description": "セキュリティポリシー"
+  },
+  {
+    "path": ".github/SUPPORT.md",
+    "description": "サポート情報"
+  },
+  {
+    "path": ".github/PULL_REQUEST_TEMPLATE.md",
+    "description": "PR テンプレート"
+  },
+  {
+    "path": ".github/ISSUE_TEMPLATE/config.yml",
+    "description": "Issue テンプレートの設定ファイル"
+  }
+]

--- a/scripts/setup-repository-health-files.sh
+++ b/scripts/setup-repository-health-files.sh
@@ -27,19 +27,23 @@ fi
 require_command "gh" "GitHub CLI (gh) が必要です。PATH を確認してください。"
 require_command "jq" "JSON の解析に必要です。"
 
-# --- 対象ファイル定義 ---
+# --- 対象ファイル定義（JSON から読み込み） ---
 
-HEALTH_FILES=(
-  ".github/CODE_OF_CONDUCT.md"
-  ".github/CONTRIBUTING.md"
-  ".github/GOVERNANCE.md"
-  ".github/SECURITY.md"
-  ".github/SUPPORT.md"
-  ".github/PULL_REQUEST_TEMPLATE.md"
-  ".github/ISSUE_TEMPLATE/config.yml"
-)
+CONFIG_DIR="${SCRIPT_DIR}/config"
+HEALTH_FILE_DEFINITIONS="${CONFIG_DIR}/health-file-definitions.json"
 
+if [[ ! -f "${HEALTH_FILE_DEFINITIONS}" ]]; then
+  echo "::error::設定ファイルが見つかりません: ${HEALTH_FILE_DEFINITIONS}"
+  exit 1
+fi
+
+mapfile -t HEALTH_FILES < <(jq -r '.[].path' "${HEALTH_FILE_DEFINITIONS}")
 FILE_COUNT=${#HEALTH_FILES[@]}
+
+if [[ "${FILE_COUNT}" -eq 0 ]]; then
+  echo "::error::設定ファイルに対象ファイルが定義されていません。"
+  exit 1
+fi
 
 # --- デフォルトブランチの取得 ---
 


### PR DESCRIPTION
## Summary
- `scripts/setup-repository-health-files.sh` 内にハードコードされていた対象ファイル定義（Bash 配列）を `scripts/config/health-file-definitions.json` に外出し
- スクリプトを `jq` で JSON を読み取る方式に変更し、他スクリプトと同様の設計パターンに統一
- ドキュメント（スクリプト・ワークフロー）に JSON 定義ファイルの説明とカスタマイズ方法を追加

## Test plan
- [ ] `jq -r '.[].path' scripts/config/health-file-definitions.json` で 7 件のパスが出力されることを確認
- [ ] JSON ファイルが存在しない場合にスクリプトがエラー終了することを確認
- [ ] JSON ファイルが空配列の場合にスクリプトがエラー終了することを確認
- [ ] ワークフロー実行で既存と同じ動作になることを確認

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)