### PR TITLE
refactor: scripts 配下のコード品質改善とドキュメント最新化

### DIFF
--- a/docs/scripts/add-items-to-project.md
+++ b/docs/scripts/add-items-to-project.md
@@ -73,10 +73,10 @@ flowchart TD
 |---------|---------|-------------------|
 | オーナータイプ判定 | `detect_owner_type` で `Organization` / `User` を判別 | `gh api users/{owner}` |
 | `Status` Field 取得 | GraphQL で `Project ID`・`Status Field ID`・各 Status の `Option ID` を一括抽出 | `gh api graphql` — `projectV2.fields` |
-| 既存 Item 取得 | GraphQL クエリで Project に紐づく全 Item の URL をページネーション付きで取得。重複防止に使用 | `gh api graphql` — `projectV2.items(first: 100)` |
-| Item 取得・追加 | `fetch_and_add_items` 関数で `Issue` / `PR` を共通処理。`ITEM_STATE`・`ITEM_LABEL` で絞り込んで一覧を取得し、重複チェック・追加・ Status 設定を実行（`Issue` / `PR` 各種別ごとに最大 100 件、1件ごとに 1秒の sleep） | `gh issue list` / `gh pr list`・`gh project item-add`・`updateProjectV2ItemFieldValue` |
+| 既存 Item 取得 | GraphQL クエリで Project に紐づく全 Item の URL をページネーション付きで取得し、連想配列に格納。O(1) の重複チェックに使用 | `gh api graphql` — `projectV2.items(first: 100)` |
+| Item 取得・追加 | `fetch_and_add_items` 関数で `Issue` / `PR` を共通処理。`ITEM_STATE`・`ITEM_LABEL` で絞り込んで一覧を取得し、連想配列による重複チェック・追加・ Status 設定を実行（`Issue` / `PR` 各種別ごとに最大 100 件、1件ごとに 1秒の sleep） | `gh issue list` / `gh pr list`・`gh project item-add`・`updateProjectV2ItemFieldValue` |
 | Status 設定 | 追加した Item に Status を自動付与。`open → Backlog、closed/merged → Done` | `gh api graphql` — `updateProjectV2ItemFieldValue` |
-| サマリー出力 | `Issue`・`PR` それぞれの追加・スキップ・失敗件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | — |
+| サマリー出力 | `Issue`・`PR` それぞれの追加・スキップ・失敗件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `write_workflow_summary` |
 
 ## 📚 API リファレンス
 

--- a/docs/scripts/create-special-repos.md
+++ b/docs/scripts/create-special-repos.md
@@ -160,7 +160,7 @@ flowchart TD
 | 既存 Repository チェック | `gh api repos/{owner}/{repo}` で既存 Repository の存在を確認 | `gh api repos/{owner}/{repo}` |
 | Repository 作成（User） | `gh api user/repos` で Repository を作成。`visibility` を `private` パラメータに変換 | `POST /user/repos` |
 | Repository 作成（Organization） | `gh api orgs/{org}/repos` で Repository を作成。`visibility` パラメータをそのまま使用 | `POST /orgs/{org}/repos` |
-| サマリー出力 | 作成/スキップ/失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `GITHUB_STEP_SUMMARY` |
+| サマリー出力 | 作成/スキップ/失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `write_workflow_summary` |
 
 ### 実行結果サマリーの出力形式
 

--- a/docs/scripts/setup-github-project.md
+++ b/docs/scripts/setup-github-project.md
@@ -74,7 +74,7 @@ flowchart TD
 | 情報抽出 | 作成結果の JSON から `id`・`number`・`url` を取得 | `jq -c '.data.createProjectV2.projectV2'` + `jq -r '@tsv'` |
 | Visibility 設定 | 作成した `Project` の公開範囲を指定値に変更 | GraphQL `updateProjectV2(input: {projectId, public})` |
 | Visibility 検証 | レスポンス JSON の `public` が期待値と一致するか確認 | `jq '.public'` |
-| サマリー出力 | `GITHUB_OUTPUT` へ後続ステップ連携用の値を設定、`GITHUB_STEP_SUMMARY` にテーブル出力 | — |
+| サマリー出力 | `GITHUB_OUTPUT` へ後続ステップ連携用の値を設定、`GITHUB_STEP_SUMMARY` にテーブル出力 | `write_workflow_summary` |
 
 ## 📚 API リファレンス
 

--- a/docs/scripts/setup-project-fields.md
+++ b/docs/scripts/setup-project-fields.md
@@ -99,7 +99,7 @@ flowchart TD
 | 既存 Field 取得 | GraphQL クエリで `Project` ID と全 Field（名前・データ型・選択肢）を一括取得 | `gh api graphql` — `projectV2.fields(first: 100)` |
 | 重複チェック | 既存 Field 名リストと定義済み Field 名を `grep -Fqx` で完全一致比較 | — |
 | Field 作成 | データ型に応じて Field を作成（`SINGLE_SELECT` の場合は `singleSelectOptions` で選択肢を付与） | `gh api graphql` — `createProjectV2Field` mutation |
-| サマリー出力 | 作成・スキップ・失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | — |
+| サマリー出力 | 作成・スキップ・失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `write_workflow_summary` |
 
 ## 📚 API リファレンス
 

--- a/docs/scripts/setup-project-status.md
+++ b/docs/scripts/setup-project-status.md
@@ -72,7 +72,7 @@ flowchart TD
 | Status 定義ファイル読み込み | `scripts/config/project-status-options.json` から Status カラム定義を読み込み | `cat` |
 | `Status` Field 取得 | GraphQL クエリで `Project` ID と `Status` Field ID を一括取得し、現在のカラム一覧を表示 | `gh api graphql` — `projectV2.fields(first: 100)` |
 | カラム更新 | `singleSelectOptions` に Backlog（GRAY）・ Todo（BLUE）・ In Progress（YELLOW）・ In Review（ORANGE）・ Done（GREEN）を指定して一括更新 | `gh api graphql` — `updateProjectV2Field` mutation |
-| サマリー出力 | カラム構成（`Backlog → Todo → In Progress → In Review → Done`）をコンソールと `GITHUB_STEP_SUMMARY` に出力 | — |
+| サマリー出力 | カラム構成（`Backlog → Todo → In Progress → In Review → Done`）をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `write_workflow_summary` |
 
 ## 📚 API リファレンス
 

--- a/docs/scripts/setup-project-views.md
+++ b/docs/scripts/setup-project-views.md
@@ -115,7 +115,7 @@ flowchart TD
 | `View` 定義の事前解析 | ループ前に全 `View` 定義を1回の `jq` で TSV に変換し、ループ内の `jq` 呼び出しを削減 | `jq -r '.[] \| [...] \| @tsv'` |
 | 重複チェック | 既存 `View` 名リストと定義済み `View` 名を `grep -Fqx` で完全一致比較 | — |
 | `View` 作成 | REST API で `View` を作成。`name`・`layout` に加え、任意で `filter`・`visible_fields` を送信 | `gh api {path} --method POST` |
-| サマリー出力 | 作成・スキップ・失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | — |
+| サマリー出力 | 作成・スキップ・失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `write_workflow_summary` |
 
 ## 📚 API リファレンス
 

--- a/docs/scripts/setup-repository-labels.md
+++ b/docs/scripts/setup-repository-labels.md
@@ -173,7 +173,7 @@ flowchart TD
 | 重複チェック | 既存 Label 名リストと定義済み Label 名を `grep -Fqx` で完全一致比較 | — |
 | Label 作成 | 重複していない Label を `gh label create` で作成 | `gh label create -R` |
 | エラーハンドリング | 作成失敗時はエラーカウントを記録して次の Label へ続行 | — |
-| サマリー出力 | 作成/スキップ/失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `GITHUB_STEP_SUMMARY` |
+| サマリー出力 | 作成/スキップ/失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `write_workflow_summary` |
 
 ### 実行結果サマリーの出力形式
 

--- a/docs/scripts/setup-repository-rulesets.md
+++ b/docs/scripts/setup-repository-rulesets.md
@@ -171,7 +171,7 @@ flowchart TD
 | Ruleset 作成 | 重複していない Ruleset を REST API で作成 | `gh api repos/.../rulesets --method POST` |
 | enforcement 確認 | 作成後の `enforcement` が `evaluate` になった場合は警告を出力（Free プランの制約） | `jq` |
 | エラーハンドリング | 作成失敗時はエラーカウントを記録して次の Ruleset へ続行 | — |
-| サマリー出力 | 作成/スキップ/失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `GITHUB_STEP_SUMMARY` |
+| サマリー出力 | 作成/スキップ/失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `print_summary`, `write_workflow_summary` |
 
 ### 実行結果サマリーの出力形式
 

--- a/scripts/add-items-to-project.sh
+++ b/scripts/add-items-to-project.sh
@@ -23,12 +23,8 @@ source "${SCRIPT_DIR}/lib/common.sh"
 validate_common_project_env
 validate_target_repo_env
 
-ITEM_TYPE="${ITEM_TYPE:-all}"
-ITEM_STATE="${ITEM_STATE:-open}"
+validate_item_filters
 ITEM_LABEL="${ITEM_LABEL:-}"
-
-validate_enum "ITEM_TYPE" "${ITEM_TYPE}" "all" "issues" "prs"
-validate_enum "ITEM_STATE" "${ITEM_STATE}" "open" "closed" "all"
 
 # ステータス自動付与ルール: open → Backlog、closed/merged → Done
 INITIAL_STATUS="Backlog"
@@ -282,13 +278,16 @@ GRAPHQL
 echo ""
 echo "Project #${PROJECT_NUMBER} の既存 Item を取得しています..."
 EXISTING_ITEMS=$(get_existing_project_items)
+declare -A EXISTING_ITEMS_MAP=()
+EXISTING_COUNT=0
 if [[ -n "${EXISTING_ITEMS}" ]]; then
-  EXISTING_COUNT=$(echo "${EXISTING_ITEMS}" | wc -l | tr -d ' ')
-  echo "  既存 Item 数: ${EXISTING_COUNT}"
-else
-  EXISTING_COUNT=0
-  echo "  既存 Item 数: 0"
+  while IFS= read -r _url; do
+    [[ -z "${_url}" ]] && continue
+    EXISTING_ITEMS_MAP["${_url}"]=1
+    EXISTING_COUNT=$((EXISTING_COUNT + 1))
+  done <<< "${EXISTING_ITEMS}"
 fi
+echo "  既存 Item 数: ${EXISTING_COUNT}"
 
 # --- Item 取得・追加（共通関数） ---
 
@@ -328,7 +327,7 @@ fetch_and_add_items() {
     while IFS=$'\t' read -r url state; do
       [[ -z "${url}" ]] && continue
 
-      if [[ -n "${EXISTING_ITEMS}" ]] && echo "${EXISTING_ITEMS}" | grep -Fxq "${url}"; then
+      if [[ -n "${EXISTING_ITEMS_MAP["${url}"]:-}" ]]; then
         echo "  スキップ（追加済み）: ${url}" >&2
         skipped=$((skipped + 1))
         continue
@@ -401,29 +400,31 @@ print_summary \
   "PR" "追加: ${PR_ADDED}, スキップ: ${PR_SKIPPED}, 失敗: ${PR_FAILED}" \
   "合計" "追加: ${TOTAL_ADDED}, スキップ: ${TOTAL_SKIPPED}, 失敗: ${TOTAL_FAILED}"
 
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "## Project Item 一括追加 完了"
-    echo ""
-    echo "| 項目 | 値 |"
-    echo "|------|-----|"
-    echo "| Target Repo | \`${TARGET_REPO}\` |"
-    echo "| Repo Link | ${LINK_STATUS} |"
-    echo "| State Filter | ${ITEM_STATE} |"
-    echo "| Status | open → Backlog / closed・merged → Done |"
-    if [[ -n "${ITEM_LABEL}" ]]; then
-      echo "| Label Filter | ${ITEM_LABEL} |"
-    fi
-    echo "| Issue 追加 | ${ISSUE_ADDED} 件 |"
-    echo "| Issue スキップ | ${ISSUE_SKIPPED} 件 |"
-    echo "| Issue 失敗 | ${ISSUE_FAILED} 件 |"
-    echo "| PR 追加 | ${PR_ADDED} 件 |"
-    echo "| PR スキップ | ${PR_SKIPPED} 件 |"
-    echo "| PR 失敗 | ${PR_FAILED} 件 |"
-    echo "| **合計追加** | **${TOTAL_ADDED} 件** |"
-    echo "| **合計失敗** | **${TOTAL_FAILED} 件** |"
-  } >> "${GITHUB_STEP_SUMMARY}"
-fi
+{
+  cat <<MD
+## Project Item 一括追加 完了
+
+| 項目 | 値 |
+|------|-----|
+| Target Repo | \`${TARGET_REPO}\` |
+| Repo Link | ${LINK_STATUS} |
+| State Filter | ${ITEM_STATE} |
+| Status | open → Backlog / closed・merged → Done |
+MD
+  if [[ -n "${ITEM_LABEL}" ]]; then
+    echo "| Label Filter | ${ITEM_LABEL} |"
+  fi
+  cat <<MD
+| Issue 追加 | ${ISSUE_ADDED} 件 |
+| Issue スキップ | ${ISSUE_SKIPPED} 件 |
+| Issue 失敗 | ${ISSUE_FAILED} 件 |
+| PR 追加 | ${PR_ADDED} 件 |
+| PR スキップ | ${PR_SKIPPED} 件 |
+| PR 失敗 | ${PR_FAILED} 件 |
+| **合計追加** | **${TOTAL_ADDED} 件** |
+| **合計失敗** | **${TOTAL_FAILED} 件** |
+MD
+} | write_workflow_summary
 
 echo ""
 if [[ "${TOTAL_FAILED}" -gt 0 ]]; then

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -225,23 +225,23 @@ create_files_via_pr() {
 output_repo_files_summary() {
   local summary_title="$1"
 
-  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-    {
-      echo "## ${summary_title}"
+  {
+    cat <<MD
+## ${summary_title}
+
+| 項目 | 件数 |
+|------|------|
+| 作成 | ${CREATED_COUNT} |
+| スキップ | ${SKIPPED_COUNT} |
+| 失敗 | ${FAILED_COUNT} |
+MD
+    if [[ -n "${PR_URL:-}" ]] && [[ "${PR_URL}" == http* ]]; then
       echo ""
-      echo "| 項目 | 件数 |"
-      echo "|------|------|"
-      echo "| 作成 | ${CREATED_COUNT} |"
-      echo "| スキップ | ${SKIPPED_COUNT} |"
-      echo "| 失敗 | ${FAILED_COUNT} |"
-      if [[ -n "${PR_URL:-}" ]] && [[ "${PR_URL}" == http* ]]; then
-        echo ""
-        echo "### 作成された PR"
-        echo ""
-        echo "- ${PR_URL}"
-      fi
-    } >> "${GITHUB_STEP_SUMMARY}"
-  fi
+      echo "### 作成された PR"
+      echo ""
+      echo "- ${PR_URL}"
+    fi
+  } | write_workflow_summary
 
   print_summary "Repository" "${TARGET_REPO}" "作成" "${CREATED_COUNT} 件" "スキップ" "${SKIPPED_COUNT} 件" "失敗" "${FAILED_COUNT} 件"
 
@@ -524,6 +524,16 @@ JQ_MD_ESCAPE='def md_escape: gsub("\\\\"; "\\\\") | gsub("`"; "\\`") | gsub("\\*
 # 使用例: echo "${DATA}" | jq "${JQ_STATUS_ORDER}"'sort_by(status_order(.status))'
 JQ_STATUS_ORDER='def status_order(s): if s == "Backlog" then 0 elif s == "Todo" then 1 elif s == "In Progress" then 2 elif s == "In Review" then 3 elif s == "Done" then 4 else 5 end;'
 
+# ITEM_TYPE / ITEM_STATE のバリデーションを行う
+# デフォルト値の設定と validate_enum を一括実行する
+# 使用例: validate_item_filters
+validate_item_filters() {
+  ITEM_TYPE="${ITEM_TYPE:-all}"
+  ITEM_STATE="${ITEM_STATE:-open}"
+  validate_enum "ITEM_TYPE" "${ITEM_TYPE}" "all" "issues" "prs"
+  validate_enum "ITEM_STATE" "${ITEM_STATE}" "open" "closed" "all"
+}
+
 # ITEM_TYPE フィルタ用ヘルパー関数
 # ITEM_TYPE 環境変数の値に応じて Issue / PR を含めるかどうかを判定する
 should_include_issues() { [[ "${ITEM_TYPE}" == "all" || "${ITEM_TYPE}" == "issues" ]]; }
@@ -572,6 +582,24 @@ build_output_filename() {
   local file_ext
   file_ext=$(get_file_extension "${OUTPUT_FORMAT}")
   echo "${prefix}-${PROJECT_NUMBER}-${suffix}.${file_ext}"
+}
+
+# GitHub Actions の Workflow Summary にコンテンツを追記する
+# GITHUB_STEP_SUMMARY が未設定の場合は何もしない
+# 引数: 標準入力から Markdown コンテンツを受け取る
+# 使用例:
+#   write_workflow_summary <<'MD'
+#   ## タイトル
+#   | 項目 | 値 |
+#   |------|-----|
+#   | 作成 | 3 件 |
+#   MD
+write_workflow_summary() {
+  if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat > /dev/null
+    return
+  fi
+  cat >> "${GITHUB_STEP_SUMMARY}"
 }
 
 # レポート結果を Workflow Summary に追記する
@@ -664,12 +692,10 @@ validate_analysis_env() {
 
   validate_common_project_env
 
-  ITEM_TYPE="${ITEM_TYPE:-all}"
   ITEM_STATE="${ITEM_STATE:-all}"
   OUTPUT_FORMAT="${OUTPUT_FORMAT:-${default_format}}"
 
-  validate_enum "ITEM_TYPE" "${ITEM_TYPE}" "all" "issues" "prs"
-  validate_enum "ITEM_STATE" "${ITEM_STATE}" "open" "closed" "all"
+  validate_item_filters
   validate_enum "OUTPUT_FORMAT" "${OUTPUT_FORMAT}" "markdown" "csv" "tsv" "json"
 }
 
@@ -826,17 +852,15 @@ create_repos_batch() {
 
   # --- サマリー出力 ---
 
-  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-    {
-      echo "## ${type_label_ja}特殊 Repository 一括作成完了"
-      echo ""
-      echo "| 項目 | 件数 |"
-      echo "|------|------|"
-      echo "| 作成 | ${created_count} |"
-      echo "| スキップ | ${skipped_count} |"
-      echo "| 失敗 | ${failed_count} |"
-    } >> "${GITHUB_STEP_SUMMARY}"
-  fi
+  write_workflow_summary <<MD
+## ${type_label_ja}特殊 Repository 一括作成完了
+
+| 項目 | 件数 |
+|------|------|
+| 作成 | ${created_count} |
+| スキップ | ${skipped_count} |
+| 失敗 | ${failed_count} |
+MD
 
   print_summary "Owner" "${PROJECT_OWNER}" "タイプ" "${owner_type_label}" "作成" "${created_count} 件" "スキップ" "${skipped_count} 件" "失敗" "${failed_count} 件"
 

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -177,20 +177,17 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "project_url=${PROJECT_URL}" >> "${GITHUB_OUTPUT}"
 fi
 
-# GitHub Actions のサマリーに出力
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "## GitHub Project 作成完了"
-    echo ""
-    echo "| 項目 | 値 |"
-    echo "|------|-----|"
-    echo "| Title | ${PROJECT_TITLE} |"
-    echo "| Type | ${OWNER_TYPE} |"
-    echo "| Visibility | ${PROJECT_VISIBILITY} |"
-    echo "| Number | ${PROJECT_NUMBER} |"
-    echo "| URL | ${PROJECT_URL} |"
-  } >> "${GITHUB_STEP_SUMMARY}"
-fi
+write_workflow_summary <<MD
+## GitHub Project 作成完了
+
+| 項目 | 値 |
+|------|-----|
+| Title | ${PROJECT_TITLE} |
+| Type | ${OWNER_TYPE} |
+| Visibility | ${PROJECT_VISIBILITY} |
+| Number | ${PROJECT_NUMBER} |
+| URL | ${PROJECT_URL} |
+MD
 
 echo ""
 echo "セットアップが完了しました。"

--- a/scripts/setup-project-fields.sh
+++ b/scripts/setup-project-fields.sh
@@ -164,23 +164,23 @@ done <<< "${PARSED_FIELDS}"
 
 print_summary "作成" "${CREATED_COUNT} 件" "スキップ" "${SKIPPED_COUNT} 件（既存）" "失敗" "${FAILED_COUNT} 件"
 
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "## Field 設定完了"
-    echo ""
-    echo "| 項目 | 値 |"
-    echo "|------|-----|"
-    echo "| 作成 | ${CREATED_COUNT} 件 |"
-    echo "| スキップ | ${SKIPPED_COUNT} 件（既存） |"
-    echo "| 失敗 | ${FAILED_COUNT} 件 |"
-    echo ""
-    echo "### Field 一覧"
-    echo ""
-    echo "| フィールド名 | データ型 | 選択肢 |"
-    echo "|-------------|---------|--------|"
-    echo "${FIELD_DEFINITIONS}" | jq -r '.[] | "| \(.name) | \(.dataType) | \(if .options then (.options | join(", ")) else "-" end) |"'
-  } >> "${GITHUB_STEP_SUMMARY}"
-fi
+{
+  cat <<MD
+## Field 設定完了
+
+| 項目 | 値 |
+|------|-----|
+| 作成 | ${CREATED_COUNT} 件 |
+| スキップ | ${SKIPPED_COUNT} 件（既存） |
+| 失敗 | ${FAILED_COUNT} 件 |
+
+### Field 一覧
+
+| フィールド名 | データ型 | 選択肢 |
+|-------------|---------|--------|
+MD
+  echo "${FIELD_DEFINITIONS}" | jq -r '.[] | "| \(.name) | \(.dataType) | \(if .options then (.options | join(", ")) else "-" end) |"'
+} | write_workflow_summary
 
 if [[ "${FAILED_COUNT}" -gt 0 ]]; then
   echo ""

--- a/scripts/setup-project-status.sh
+++ b/scripts/setup-project-status.sh
@@ -140,15 +140,13 @@ echo "${UPDATE_RESULT}" | jq -r '.data.updateProjectV2Field.projectV2Field.optio
 
 COLUMN_NAMES=$(echo "${STATUS_OPTIONS}" | jq -r '[.[].name] | join(" → ")')
 
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "## ステータスカラム設定完了"
-    echo ""
-    echo "| 項目 | 値 |"
-    echo "|------|-----|"
-    echo "| カラム構成 | ${COLUMN_NAMES} |"
-  } >> "${GITHUB_STEP_SUMMARY}"
-fi
+write_workflow_summary <<MD
+## ステータスカラム設定完了
+
+| 項目 | 値 |
+|------|-----|
+| カラム構成 | ${COLUMN_NAMES} |
+MD
 
 print_summary "カラム" "${COLUMN_NAMES}"
 

--- a/scripts/setup-project-views.sh
+++ b/scripts/setup-project-views.sh
@@ -167,23 +167,23 @@ done <<< "${PARSED_VIEWS}"
 
 print_summary "作成" "${CREATED_COUNT} 件" "スキップ" "${SKIPPED_COUNT} 件（既存）" "失敗" "${FAILED_COUNT} 件"
 
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "## View 作成完了"
-    echo ""
-    echo "| 項目 | 値 |"
-    echo "|------|-----|"
-    echo "| 作成 | ${CREATED_COUNT} 件 |"
-    echo "| スキップ | ${SKIPPED_COUNT} 件（既存） |"
-    echo "| 失敗 | ${FAILED_COUNT} 件 |"
-    echo ""
-    echo "### View 一覧"
-    echo ""
-    echo "| View 名 | レイアウト | フィルタ |"
-    echo "|---------|-----------|---------|"
-    echo "${VIEW_DEFINITIONS}" | jq -r '.[] | "| \(.name) | \(.layout) | \(.filter // "-") |"'
-  } >> "${GITHUB_STEP_SUMMARY}"
-fi
+{
+  cat <<MD
+## View 作成完了
+
+| 項目 | 値 |
+|------|-----|
+| 作成 | ${CREATED_COUNT} 件 |
+| スキップ | ${SKIPPED_COUNT} 件（既存） |
+| 失敗 | ${FAILED_COUNT} 件 |
+
+### View 一覧
+
+| View 名 | レイアウト | フィルタ |
+|---------|-----------|---------|
+MD
+  echo "${VIEW_DEFINITIONS}" | jq -r '.[] | "| \(.name) | \(.layout) | \(.filter // "-") |"'
+} | write_workflow_summary
 
 if [[ "${FAILED_COUNT}" -gt 0 ]]; then
   echo ""

--- a/scripts/setup-repository-labels.sh
+++ b/scripts/setup-repository-labels.sh
@@ -117,17 +117,15 @@ done <<< "${PARSED_LABELS}"
 
 # --- サマリー出力 ---
 
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "## ラベル一括作成完了"
-    echo ""
-    echo "| 項目 | 件数 |"
-    echo "|------|------|"
-    echo "| 作成 | ${CREATED_COUNT} |"
-    echo "| スキップ | ${SKIPPED_COUNT} |"
-    echo "| 失敗 | ${FAILED_COUNT} |"
-  } >> "${GITHUB_STEP_SUMMARY}"
-fi
+write_workflow_summary <<MD
+## ラベル一括作成完了
+
+| 項目 | 件数 |
+|------|------|
+| 作成 | ${CREATED_COUNT} |
+| スキップ | ${SKIPPED_COUNT} |
+| 失敗 | ${FAILED_COUNT} |
+MD
 
 print_summary "Repository" "${TARGET_REPO}" "作成" "${CREATED_COUNT} 件" "スキップ" "${SKIPPED_COUNT} 件" "失敗" "${FAILED_COUNT} 件"
 

--- a/scripts/setup-repository-rulesets.sh
+++ b/scripts/setup-repository-rulesets.sh
@@ -95,14 +95,12 @@ EVALUATE_COUNT=0
 if [[ "${PLAN_RESTRICTED}" == true ]]; then
   echo ""
 
-  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-    {
-      echo "## Ruleset 一括作成"
-      echo ""
-      echo "> **⚠️ プラン制約:** Free プランの Private リポジトリでは Rulesets API を利用できません。"
-      echo "> リポジトリを Public にするか、GitHub Pro 以上にアップグレードしてください。"
-    } >> "${GITHUB_STEP_SUMMARY}"
-  fi
+  write_workflow_summary <<'MD'
+## Ruleset 一括作成
+
+> **⚠️ プラン制約:** Free プランの Private リポジトリでは Rulesets API を利用できません。
+> リポジトリを Public にするか、GitHub Pro 以上にアップグレードしてください。
+MD
 
   print_summary "Repository" "${TARGET_REPO}" "状態" "プラン制約によりスキップ"
   echo ""
@@ -170,23 +168,23 @@ done <<< "${PARSED_NAMES}"
 
 # --- サマリー出力 ---
 
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  {
-    echo "## Ruleset 一括作成完了"
+{
+  cat <<MD
+## Ruleset 一括作成完了
+
+| 項目 | 件数 |
+|------|------|
+| 作成 | ${CREATED_COUNT} |
+| スキップ | ${SKIPPED_COUNT} |
+| 失敗 | ${FAILED_COUNT} |
+MD
+  if [[ "${EVALUATE_COUNT}" -gt 0 ]]; then
     echo ""
-    echo "| 項目 | 件数 |"
-    echo "|------|------|"
-    echo "| 作成 | ${CREATED_COUNT} |"
-    echo "| スキップ | ${SKIPPED_COUNT} |"
-    echo "| 失敗 | ${FAILED_COUNT} |"
-    if [[ "${EVALUATE_COUNT}" -gt 0 ]]; then
-      echo ""
-      echo "> **⚠️ 注意:** ${EVALUATE_COUNT} 件の Ruleset が \`evaluate\` モードになっています。"
-      echo "> Free プラン（Private リポジトリ）では Ruleset を \`active\` にできない場合があります。"
-      echo "> 詳細は [GitHub Docs: Repository Rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) を参照してください。"
-    fi
-  } >> "${GITHUB_STEP_SUMMARY}"
-fi
+    echo "> **⚠️ 注意:** ${EVALUATE_COUNT} 件の Ruleset が \`evaluate\` モードになっています。"
+    echo "> Free プラン（Private リポジトリ）では Ruleset を \`active\` にできない場合があります。"
+    echo "> 詳細は [GitHub Docs: Repository Rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) を参照してください。"
+  fi
+} | write_workflow_summary
 
 SUMMARY_ARGS=("Repository" "${TARGET_REPO}" "作成" "${CREATED_COUNT} 件" "スキップ" "${SKIPPED_COUNT} 件" "失敗" "${FAILED_COUNT} 件")
 if [[ "${EVALUATE_COUNT}" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- `common.sh` に `validate_item_filters()` / `write_workflow_summary()` を新設し、スクリプト間の重複コードを削減
- `add-items-to-project.sh` の既存 Item 重複チェックを `grep` (O(n)) から連想配列 (O(1)) に改善
- 8 スクリプトの `GITHUB_STEP_SUMMARY` ボイラープレートを共通関数に置換
- docs: ブランチ運用ルールガイドの追加、スクリプトドキュメント 8 件のサマリー出力関数参照を最新化

closes #473

## Test plan

- [ ] 全スクリプトの `bash -n` 構文チェックが通ること（確認済み）
- [ ] `write_workflow_summary` が `GITHUB_STEP_SUMMARY` 未設定時に何も出力しないことを確認
- [ ] `validate_item_filters` が `ITEM_TYPE`/`ITEM_STATE` の検証を正しく行うことを確認
- [ ] `add-items-to-project.sh` の連想配列による重複チェックが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)