### PR TITLE
chore: GitHub Actions の uses バージョンを最新化

### DIFF
--- a/.github/workflows/01-create-project.yml
+++ b/.github/workflows/01-create-project.yml
@@ -37,7 +37,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Project を作成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/02-extend-project.yml
+++ b/.github/workflows/02-extend-project.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/03-create-special-repos.yml
+++ b/.github/workflows/03-create-special-repos.yml
@@ -22,7 +22,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 特殊 Repository を作成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/04-setup-repository-labels.yml
+++ b/.github/workflows/04-setup-repository-labels.yml
@@ -27,7 +27,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: ラベルを一括作成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/05-setup-repository-files.yml
+++ b/.github/workflows/05-setup-repository-files.yml
@@ -38,7 +38,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Community Health Files を登録
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -57,7 +57,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Scaffold ファイルを登録
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/06-setup-repository-rulesets.yml
+++ b/.github/workflows/06-setup-repository-rulesets.yml
@@ -27,7 +27,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Ruleset を一括作成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/07-add-items-to-project.yml
+++ b/.github/workflows/07-add-items-to-project.yml
@@ -54,7 +54,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Issue/PR を Project に追加
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/08-analyze-project.yml
+++ b/.github/workflows/08-analyze-project.yml
@@ -87,7 +87,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: サマリーレポート生成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: アーティファクトをアップロード
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: summary-report-${{ inputs.project_number }}
           path: report-*-summary.*
@@ -117,7 +117,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 工数集計レポート生成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: アーティファクトをアップロード
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: effort-report-${{ inputs.project_number }}
           path: report-*-effort.*
@@ -147,7 +147,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 滞留 Item 検知
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: アーティファクトをアップロード
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: stale-items-report
           path: stale-items-report.*
@@ -177,7 +177,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: ベロシティレポート生成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -185,7 +185,7 @@ jobs:
 
       - name: アーティファクトをアップロード
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: velocity-report-${{ inputs.project_number }}
           path: report-*-velocity.*
@@ -207,7 +207,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Project Item をエクスポート
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: アーティファクトをアップロード
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: export-items-${{ inputs.project_number }}
           path: export-*
@@ -228,7 +228,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/_reusable-extend-project.yml
+++ b/.github/workflows/_reusable-extend-project.yml
@@ -29,7 +29,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: ステータスカラムを設定
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'chore: release'))
     steps:
-      - uses: googleapis/release-please-action@v4.4.0
+      - uses: googleapis/release-please-action@v5.0.0
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
         with:
           token: ${{ secrets.PROJECT_PAT }}


### PR DESCRIPTION
## Summary
- `actions/checkout` を v6.0.2 → v7.0.0 に更新
- `actions/upload-artifact` を v7.0.0 → v7.0.1 に更新
- `googleapis/release-please-action` を v4.4.0 → v5.0.0 に更新
- `technote-space/toc-generator` は v4.3.1 で最新のため変更なし

## 破壊的変更の影響確認
- **checkout v7**: fork PR チェックアウトのブロック追加。本リポジトリは `workflow_dispatch` 利用のため **影響なし**
- **release-please-action v5**: Node.js 24 ランタイム更新のみ。API・入出力変更なし。**影響なし**

## Test plan
- [ ] 各ワークフローの `workflow_dispatch` 手動実行で正常動作を確認

Close #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)