### PR TITLE
chore: permissions.allow に Bash(node:*) と Bash(python3:*) を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,8 @@
   "model": "claude-opus-4-6",
   "permissions": {
     "allow": [
-      
+      "Bash(node:*)",
+      "Bash(python3:*)"
     ],
     "ask": [
       "Bash(git rm:*)",


### PR DESCRIPTION
## Summary
- `.claude/settings.json` の `permissions.allow` に `Bash(node:*)` と `Bash(python3:*)` を追加
- repo-modernization-kit からのヘッドレス実行（`claude -p`）で `.claude/settings.json` を更新可能にする
- 他の対象リポジトリ（omamori-notebook, diffuse-me 等）と同じ許可設定に統一

## Background
repo-modernization-kit の `settings-upsert` / `ai-config` ストリームがこのリポジトリに対して実行される際、
`.claude/settings.json` への Edit/Write は組み込みガードで拒否されるため Bash 経由で書き換える必要がある。
現状 `permissions.allow` が空のためヘッドレス実行が失敗していた。

## Test plan
- [ ] `permissions.allow` に `Bash(node:*)` と `Bash(python3:*)` が追加されていること
- [ ] 既存の `ask` / `deny` / `hooks` 等が変更されていないこと

close #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ujSEnYrcV9WtNScSbtpRV