### PR TITLE
chore: .claude/settings.json を最新設定に更新 [#493]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,15 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "alwaysThinkingEnabled": true,
+  "attribution": {
+    "commit": "Generated with Claude Code",
+    "pr": "Generated with Claude Code"
+  },
+  "autoMemoryEnabled": true,
+  "autoScrollEnabled": true,
+  "awaySummaryEnabled": true,
   "cleanupPeriodDays": 30,
+  "enableAllProjectMcpServers": true,
   "enabledPlugins": {},
   "env": {
     "CLAUDE_CODE_ENABLE_TELEMETRY": "false",
@@ -29,9 +37,8 @@
       }
     ]
   },
-  "includeCoAuthoredBy": true,
   "language": "japanese",
-  "model": "claude-opus-4-6",
+  "model": "claude-opus-5",
   "permissions": {
     "allow": [
       "Bash(node:*)",
@@ -44,12 +51,16 @@
     ],
     "defaultMode": "default",
     "deny": [
-      
+
     ]
   },
   "plansDirectory": ".claude/plans/",
   "promptSuggestionEnabled": true,
   "respectGitignore": true,
   "spinnerTipsEnabled": false,
-  "teammateMode": "tmux"
+  "teammateMode": "tmux",
+  "voice": {
+    "enabled": true,
+    "mode": "tap"
+  }
 }


### PR DESCRIPTION
## 概要

`.claude/settings.json` の設定を他リポジトリと統一し、最新の Claude Code 機能を有効化する。

## 変更内容

- chore: .claude/settings.json を最新設定に更新 [#493]

### 追加した設定
- `attribution.commit` / `attribution.pr`: コミット・PR への帰属表示
- `autoMemoryEnabled`: 自動メモリ機能
- `autoScrollEnabled`: 自動スクロール機能
- `awaySummaryEnabled`: 離席中サマリー機能
- `enableAllProjectMcpServers`: プロジェクト MCP サーバー有効化
- `voice.enabled` / `voice.mode`: 音声入力機能

### 変更した設定
- `model`: `claude-opus-4-6` → `claude-opus-5`

### 削除した設定
- `includeCoAuthoredBy`: `attribution` ブロックに置き換え

## 動作確認

- [ ] Bash スクリプトの構文確認（shellcheck、または目視）— 該当なし
- [ ] YAML の構文確認（yamllint / actionlint、または目視）— 該当なし
- [x] JSON 設定の構文確認（jq）

## 影響範囲

- `.claude/settings.json` のみ（Claude Code の動作設定）

## セルフレビュー

- [x] 変更差分をセルフレビューしました

## 補足

なし

## 関連 Issue

Closes #493

## ブランチ

- 作業ブランチ: `issues/#493`
- マージ先ブランチ: `main`
- [x] 作業ブランチとマージ先ブランチの組み合わせを確認しました
