### PR TITLE
chore: actions/checkout を v7.0.1 に更新 [#492]

### DIFF
--- a/.github/workflows/01-create-project.yml
+++ b/.github/workflows/01-create-project.yml
@@ -37,7 +37,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Project を作成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/02-extend-project.yml
+++ b/.github/workflows/02-extend-project.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/03-create-special-repos.yml
+++ b/.github/workflows/03-create-special-repos.yml
@@ -22,7 +22,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 特殊 Repository を作成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/04-setup-repository-labels.yml
+++ b/.github/workflows/04-setup-repository-labels.yml
@@ -27,7 +27,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: ラベルを一括作成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/05-setup-repository-files.yml
+++ b/.github/workflows/05-setup-repository-files.yml
@@ -38,7 +38,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Community Health Files を登録
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -57,7 +57,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Scaffold ファイルを登録
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/06-setup-repository-rulesets.yml
+++ b/.github/workflows/06-setup-repository-rulesets.yml
@@ -27,7 +27,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Ruleset を一括作成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/07-add-items-to-project.yml
+++ b/.github/workflows/07-add-items-to-project.yml
@@ -54,7 +54,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Issue/PR を Project に追加
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/08-analyze-project.yml
+++ b/.github/workflows/08-analyze-project.yml
@@ -87,7 +87,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: サマリーレポート生成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -117,7 +117,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 工数集計レポート生成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -147,7 +147,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 滞留 Item 検知
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -177,7 +177,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: ベロシティレポート生成
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -207,7 +207,7 @@ jobs:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Project Item をエクスポート
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}
@@ -228,7 +228,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 失敗サマリーを出力
         uses: ./.github/actions/workflow-summary
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 成功サマリーを出力
         uses: ./.github/actions/workflow-summary

--- a/.github/workflows/_reusable-extend-project.yml
+++ b/.github/workflows/_reusable-extend-project.yml
@@ -29,7 +29,7 @@ jobs:
     # スクリプト内の require_command チェックはローカル実行時の UX 向上目的で残している
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: ステータスカラムを設定
         if: ${{ startsWith(env.PROJECT_PAT, 'ghp_') || startsWith(env.PROJECT_PAT, 'github_pat_') }}


### PR DESCRIPTION
## 概要

全ワークフローファイルの `actions/checkout` を `v7.0.0` → `v7.0.1` に更新し、パッチ修正を取り込む。

## 変更内容

- chore: actions/checkout を v7.0.1 に更新 [#492]

## 動作確認

- [ ] Bash スクリプトの構文確認（shellcheck、または目視）— 該当なし
- [x] YAML の構文確認（yamllint / actionlint、または目視）
- [ ] JSON 設定の構文確認（jq）— 該当なし

## 影響範囲

`.github/workflows/` 配下の全9ワークフローファイル（01〜08 + _reusable-extend-project.yml）

## セルフレビュー

- [x] 変更差分をセルフレビューしました

## 補足

なし

## 関連 Issue

Closes #492

## ブランチ

- 作業ブランチ: `issues/#492`
- マージ先ブランチ: `main`
- [x] 作業ブランチとマージ先ブランチの組み合わせを確認しました
