### PR TITLE
feat: scaffold 定義に 11 ファイルを追加し、ファイルごとのコンテンツ指定に対応 [#496]

### DIFF
--- a/docs/scripts/setup-repository-scaffold-files.md
+++ b/docs/scripts/setup-repository-scaffold-files.md
@@ -1,7 +1,8 @@
 # 📜 setup-repository-scaffold-files.sh
 
-指定 Repository に対して、開発に必要な Scaffold ファイルを空ファイルとして一括登録するスクリプトです。
+指定 Repository に対して、開発に必要な Scaffold ファイルを一括登録するスクリプトです。
 作業ブランチを作成し、Contents API でファイルを登録した後、デフォルトブランチへの PR を作成します。
+JSON 定義に `content` フィールドが指定されたファイルはその内容で、未指定のファイルは空ファイル（改行のみ）で作成されます。
 既にファイルが存在する場合はスキップします（上書き禁止）。
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -32,29 +33,40 @@
 
 ## 📋 対象ファイル
 
-以下の Scaffold ファイルを空ファイルとして登録します。
+以下の Scaffold ファイルを登録します。
 対象ファイルは `scripts/config/repo-scaffold-definitions.json` で定義されており、ユーザーがスクリプトを直接編集せずにカスタマイズできます。
 
-| ファイル | パス | 説明 |
-|----------|------|------|
-| `.gitignore` | `.claude/.gitignore` | Claude Code 用 gitignore |
-| `.gitkeep` | `.claude/.gitkeep` | Claude Code 設定ディレクトリの保持 |
-| `.gitignore` | `.cline/.gitignore` | Cline 用 gitignore |
-| `.gitkeep` | `.cline/.gitkeep` | Cline 設定ディレクトリの保持 |
-| `.gitignore` | `.codex/.gitignore` | OpenAI Codex CLI 用 gitignore |
-| `.gitkeep` | `.codex/.gitkeep` | OpenAI Codex CLI 設定ディレクトリの保持 |
-| `.gitignore` | `.cursor/.gitignore` | Cursor 用 gitignore |
-| `.gitkeep` | `.cursor/.gitkeep` | Cursor 設定ディレクトリの保持 |
-| `.gitignore` | `.gemini/.gitignore` | Gemini 用 gitignore |
-| `.gitkeep` | `.gemini/.gitkeep` | Gemini 設定ディレクトリの保持 |
-| `copilot-instructions.md` | `.github/copilot-instructions.md` | GitHub Copilot カスタム指示ファイル |
-| `release.yml` | `.github/release.yml` | リリースノート自動生成設定 |
-| `.gitkeep` | `.idea/.gitkeep` | JetBrains IDE 設定ディレクトリの保持 |
-| `.gitkeep` | `.vscode/.gitkeep` | VS Code 設定ディレクトリの保持 |
-| `.gitignore` | `.windsurf/.gitignore` | Windsurf 用 gitignore |
-| `.gitkeep` | `.windsurf/.gitkeep` | Windsurf 設定ディレクトリの保持 |
-| `.gitignore` | `.gitignore` | プロジェクト用 gitignore |
-| `README.md` | `README.md` | プロジェクト README |
+| ファイル | パス | 説明 | 初期コンテンツ |
+|----------|------|------|:-:|
+| `.gitignore` | `.agents/skills/.gitignore` | Claude Code カスタムスキル用 gitignore | 空 |
+| `.gitkeep` | `.agents/skills/.gitkeep` | Claude Code カスタムスキルディレクトリの保持 | 空 |
+| `.gitignore` | `.claude/.gitignore` | Claude Code 用 gitignore | 空 |
+| `.gitkeep` | `.claude/.gitkeep` | Claude Code 設定ディレクトリの保持 | 空 |
+| `settings.json` | `.claude/settings.json` | Claude Code プロジェクト設定 | `{}` |
+| `.gitignore` | `.cline/.gitignore` | Cline 用 gitignore | 空 |
+| `.gitkeep` | `.cline/.gitkeep` | Cline 設定ディレクトリの保持 | 空 |
+| `.gitignore` | `.codex/.gitignore` | OpenAI Codex CLI 用 gitignore | 空 |
+| `.gitkeep` | `.codex/.gitkeep` | OpenAI Codex CLI 設定ディレクトリの保持 | 空 |
+| `.gitignore` | `.cursor/.gitignore` | Cursor 用 gitignore | 空 |
+| `.gitkeep` | `.cursor/.gitkeep` | Cursor 設定ディレクトリの保持 | 空 |
+| `.gitignore` | `.gemini/.gitignore` | Gemini 用 gitignore | 空 |
+| `.gitkeep` | `.gemini/.gitkeep` | Gemini 設定ディレクトリの保持 | 空 |
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | GitHub Copilot カスタム指示ファイル | 空 |
+| `release.yml` | `.github/release.yml` | リリースノート自動生成設定 | 空 |
+| `.gitkeep` | `.idea/.gitkeep` | JetBrains IDE 設定ディレクトリの保持 | 空 |
+| `.gitkeep` | `.vscode/.gitkeep` | VS Code 設定ディレクトリの保持 | 空 |
+| `extensions.json` | `.vscode/extensions.json` | VS Code 推奨拡張機能定義 | `{}` |
+| `launch.json` | `.vscode/launch.json` | VS Code デバッグ構成 | `{}` |
+| `settings.json` | `.vscode/settings.json` | VS Code エディタ設定 | `{}` |
+| `.gitignore` | `.windsurf/.gitignore` | Windsurf 用 gitignore | 空 |
+| `.gitkeep` | `.windsurf/.gitkeep` | Windsurf 設定ディレクトリの保持 | 空 |
+| `.editorconfig` | `.editorconfig` | エディタ横断フォーマット設定 | 空 |
+| `.gitattributes` | `.gitattributes` | Git 属性設定 | 空 |
+| `.gitignore` | `.gitignore` | プロジェクト用 gitignore | 空 |
+| `.mcp.json` | `.mcp.json` | MCP サーバー設定 | `{}` |
+| `AGENTS.md` | `AGENTS.md` | AI コーディングアシスタント向けプロジェクト説明 | 空 |
+| `DESIGN.md` | `DESIGN.md` | 設計方針・アーキテクチャドキュメント | 空 |
+| `README.md` | `README.md` | プロジェクト README | 空 |
 
 ### 設定ファイルのカスタマイズ
 
@@ -65,6 +77,11 @@
   {
     "path": ".vscode/.gitkeep",
     "description": "VS Code 設定ディレクトリの保持"
+  },
+  {
+    "path": ".vscode/settings.json",
+    "description": "VS Code エディタ設定",
+    "content": "{}"
   }
 ]
 ```
@@ -73,6 +90,7 @@
 |------------|------|:----:|
 | `path` | Repository 内のファイルパス | ✅ |
 | `description` | ファイルの説明 | — |
+| `content` | ファイルの初期コンテンツ（未指定の場合は空ファイル） | — |
 
 ## 📊 処理フロー
 
@@ -91,7 +109,7 @@ flowchart TD
     G -- "Yes" --> J["作業ブランチ作成\n（git/refs API）"]
     J --> K["ファイルをループ処理"]
 
-    K --> L["Contents API で\n空ファイル作成"]
+    K --> L["Contents API で\nファイル作成"]
     L --> M["結果を記録\n（作成 / 失敗）"]
 
     M --> N{"次のファイル\nあり?"}
@@ -112,7 +130,7 @@ flowchart TD
 | 設定ファイル読み込み | `load_config_file` で Scaffold 定義 JSON を読み込み | `common.sh` |
 | デフォルトブランチ取得 | `get_default_branch_info` でブランチ名と SHA を一括取得 | `common.sh` → `GET /repos/{owner}/{repo}`, `GET /repos/{owner}/{repo}/git/ref/heads/{branch}` |
 | 既存ファイルチェック | `check_existing_repo_files` で対象ファイルごとに Contents API で存在確認。存在すればスキップ | `common.sh` → `GET /repos/{owner}/{repo}/contents/{path}` |
-| ファイル登録 & PR 作成 | `create_files_via_pr` で作業ブランチ作成、空ファイル登録、PR 作成を一括実行 | `common.sh` → `POST /repos/{owner}/{repo}/git/refs`, `PUT /repos/{owner}/{repo}/contents/{path}`, `gh pr create` |
+| ファイル登録 & PR 作成 | `create_files_via_pr` で作業ブランチ作成、ファイル登録、PR 作成を一括実行。`FILE_CONTENT_MAP` に初期コンテンツが設定されている場合はその内容で、未設定の場合は空（改行のみ）で作成 | `common.sh` → `POST /repos/{owner}/{repo}/git/refs`, `PUT /repos/{owner}/{repo}/contents/{path}`, `gh pr create` |
 | サマリー出力 | `output_repo_files_summary` で作成/スキップ/失敗の件数をコンソールと `GITHUB_STEP_SUMMARY` に出力 | `common.sh` |
 
 ### 実行結果サマリーの出力形式
@@ -165,7 +183,7 @@ Fine-grained PAT の場合は、対象 Repository に対する **Contents** と 
 |---------|------|------|
 | REST API (Core) | 5,000 リクエスト/時 | 認証済みユーザーの場合 |
 
-対象ファイル 18 件に対して、既存チェック (18) + ブランチ作成 (1) + ファイル作成 (最大 18) + PR 作成 (1) = 最大 38 リクエストを消費します。
+対象ファイル 29 件に対して、既存チェック (29) + ブランチ作成 (1) + ファイル作成 (最大 29) + PR 作成 (1) = 最大 60 リクエストを消費します。
 レート制限の影響はありません。
 
 ## 🔄 使用 Workflow

--- a/docs/workflows/05-setup-repository-files.md
+++ b/docs/workflows/05-setup-repository-files.md
@@ -73,26 +73,37 @@ JSON ファイルを編集することで、スクリプトを変更せずに登
 対象ファイルは [`scripts/config/repo-scaffold-definitions.json`](../../scripts/config/repo-scaffold-definitions.json) で定義されています。
 JSON ファイルを編集することで、スクリプトを変更せずに登録対象をカスタマイズできます。
 
-| ファイル | パス |
-|----------|------|
-| `.gitignore` | `.claude/.gitignore` |
-| `.gitkeep` | `.claude/.gitkeep` |
-| `.gitignore` | `.cline/.gitignore` |
-| `.gitkeep` | `.cline/.gitkeep` |
-| `.gitignore` | `.codex/.gitignore` |
-| `.gitkeep` | `.codex/.gitkeep` |
-| `.gitignore` | `.cursor/.gitignore` |
-| `.gitkeep` | `.cursor/.gitkeep` |
-| `.gitignore` | `.gemini/.gitignore` |
-| `.gitkeep` | `.gemini/.gitkeep` |
-| `copilot-instructions.md` | `.github/copilot-instructions.md` |
-| `release.yml` | `.github/release.yml` |
-| `.gitkeep` | `.idea/.gitkeep` |
-| `.gitkeep` | `.vscode/.gitkeep` |
-| `.gitignore` | `.windsurf/.gitignore` |
-| `.gitkeep` | `.windsurf/.gitkeep` |
-| `.gitignore` | `.gitignore` |
-| `README.md` | `README.md` |
+| ファイル | パス | 初期コンテンツ |
+|----------|------|:-:|
+| `.gitignore` | `.agents/skills/.gitignore` | 空 |
+| `.gitkeep` | `.agents/skills/.gitkeep` | 空 |
+| `.gitignore` | `.claude/.gitignore` | 空 |
+| `.gitkeep` | `.claude/.gitkeep` | 空 |
+| `settings.json` | `.claude/settings.json` | `{}` |
+| `.gitignore` | `.cline/.gitignore` | 空 |
+| `.gitkeep` | `.cline/.gitkeep` | 空 |
+| `.gitignore` | `.codex/.gitignore` | 空 |
+| `.gitkeep` | `.codex/.gitkeep` | 空 |
+| `.gitignore` | `.cursor/.gitignore` | 空 |
+| `.gitkeep` | `.cursor/.gitkeep` | 空 |
+| `.gitignore` | `.gemini/.gitignore` | 空 |
+| `.gitkeep` | `.gemini/.gitkeep` | 空 |
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | 空 |
+| `release.yml` | `.github/release.yml` | 空 |
+| `.gitkeep` | `.idea/.gitkeep` | 空 |
+| `.gitkeep` | `.vscode/.gitkeep` | 空 |
+| `extensions.json` | `.vscode/extensions.json` | `{}` |
+| `launch.json` | `.vscode/launch.json` | `{}` |
+| `settings.json` | `.vscode/settings.json` | `{}` |
+| `.gitignore` | `.windsurf/.gitignore` | 空 |
+| `.gitkeep` | `.windsurf/.gitkeep` | 空 |
+| `.editorconfig` | `.editorconfig` | 空 |
+| `.gitattributes` | `.gitattributes` | 空 |
+| `.gitignore` | `.gitignore` | 空 |
+| `.mcp.json` | `.mcp.json` | `{}` |
+| `AGENTS.md` | `AGENTS.md` | 空 |
+| `DESIGN.md` | `DESIGN.md` | 空 |
+| `README.md` | `README.md` | 空 |
 
 ## 📊 処理フロー
 

--- a/scripts/config/repo-scaffold-definitions.json
+++ b/scripts/config/repo-scaffold-definitions.json
@@ -1,11 +1,24 @@
 [
   {
+    "path": ".agents/skills/.gitignore",
+    "description": "Claude Code カスタムスキル用 gitignore"
+  },
+  {
+    "path": ".agents/skills/.gitkeep",
+    "description": "Claude Code カスタムスキルディレクトリの保持"
+  },
+  {
     "path": ".claude/.gitignore",
     "description": "Claude Code 用 gitignore"
   },
   {
     "path": ".claude/.gitkeep",
     "description": "Claude Code 設定ディレクトリの保持"
+  },
+  {
+    "path": ".claude/settings.json",
+    "description": "Claude Code プロジェクト設定",
+    "content": "{}"
   },
   {
     "path": ".cline/.gitignore",
@@ -56,6 +69,21 @@
     "description": "VS Code 設定ディレクトリの保持"
   },
   {
+    "path": ".vscode/extensions.json",
+    "description": "VS Code 推奨拡張機能定義",
+    "content": "{}"
+  },
+  {
+    "path": ".vscode/launch.json",
+    "description": "VS Code デバッグ構成",
+    "content": "{}"
+  },
+  {
+    "path": ".vscode/settings.json",
+    "description": "VS Code エディタ設定",
+    "content": "{}"
+  },
+  {
     "path": ".windsurf/.gitignore",
     "description": "Windsurf 用 gitignore"
   },
@@ -64,8 +92,29 @@
     "description": "Windsurf 設定ディレクトリの保持"
   },
   {
+    "path": ".editorconfig",
+    "description": "エディタ横断フォーマット設定"
+  },
+  {
+    "path": ".gitattributes",
+    "description": "Git 属性設定"
+  },
+  {
     "path": ".gitignore",
     "description": "プロジェクト用 gitignore"
+  },
+  {
+    "path": ".mcp.json",
+    "description": "MCP サーバー設定",
+    "content": "{}"
+  },
+  {
+    "path": "AGENTS.md",
+    "description": "AI コーディングアシスタント向けプロジェクト説明"
+  },
+  {
+    "path": "DESIGN.md",
+    "description": "設計方針・アーキテクチャドキュメント"
   },
   {
     "path": "README.md",

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -164,10 +164,10 @@ create_files_via_pr() {
     echo "  [${file_index}/${#FILES_TO_CREATE[@]}] ${file_path}"
 
     local content_base64
-    if [[ -n "${FILE_CONTENT_MAP[${file_path}]+x}" ]]; then
-      content_base64=$(printf '%s\n' "${FILE_CONTENT_MAP[${file_path}]}" | base64)
+    if [[ -n "${FILE_CONTENT_MAP[$file_path]+x}" ]]; then
+      content_base64=$(printf '%s\n' "${FILE_CONTENT_MAP[$file_path]}" | base64 -w0)
     else
-      content_base64=$(printf '\n' | base64)
+      content_base64=$(printf '\n' | base64 -w0)
     fi
 
     if gh api "repos/${target_repo}/contents/${file_path}" \

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -8,6 +8,10 @@
 
 REST_API_VERSION="2022-11-28"
 
+# ファイルパスごとの初期コンテンツを保持する連想配列
+# 呼び出し元スクリプトが設定する。未設定のパスは改行のみ（空ファイル）で作成される
+declare -A FILE_CONTENT_MAP=()
+
 # 設定ファイルを読み込み、存在チェックを行う
 # 使用例: DEFINITIONS=$(load_config_file "${SCRIPT_DIR}/config/repo-label-definitions.json" "ラベル定義ファイル")
 load_config_file() {
@@ -109,7 +113,8 @@ check_existing_repo_files() {
   done
 }
 
-# 作業ブランチを作成し、空ファイルを登録して PR を作成する
+# 作業ブランチを作成し、ファイルを登録して PR を作成する
+# FILE_CONTENT_MAP に初期コンテンツが設定されている場合はその内容で、未設定の場合は空（改行のみ）で作成する
 # 引数:
 #   $1 - target_repo: 対象 Repository（owner/repo 形式）
 #   $2 - work_branch: 作業ブランチ名
@@ -159,7 +164,11 @@ create_files_via_pr() {
     echo "  [${file_index}/${#FILES_TO_CREATE[@]}] ${file_path}"
 
     local content_base64
-    content_base64=$(printf '\n' | base64)
+    if [[ -n "${FILE_CONTENT_MAP[${file_path}]+x}" ]]; then
+      content_base64=$(printf '%s\n' "${FILE_CONTENT_MAP[${file_path}]}" | base64)
+    else
+      content_base64=$(printf '\n' | base64)
+    fi
 
     if gh api "repos/${target_repo}/contents/${file_path}" \
       -H "X-GitHub-Api-Version: ${REST_API_VERSION}" \

--- a/scripts/setup-repository-scaffold-files.sh
+++ b/scripts/setup-repository-scaffold-files.sh
@@ -25,6 +25,12 @@ validate_target_repo_env
 SCAFFOLD_FILE_DEFINITIONS=$(load_config_file "${SCRIPT_DIR}/config/repo-scaffold-definitions.json" "Scaffold 定義ファイル")
 
 mapfile -t SCAFFOLD_FILES < <(echo "${SCAFFOLD_FILE_DEFINITIONS}" | jq -r '.[].path')
+
+while IFS=$'\t' read -r _path _content; do
+  if [[ -n "${_content}" ]]; then
+    FILE_CONTENT_MAP["${_path}"]="${_content}"
+  fi
+done < <(echo "${SCAFFOLD_FILE_DEFINITIONS}" | jq -r '.[] | select(.content != null) | [.path, .content] | @tsv')
 FILE_COUNT=${#SCAFFOLD_FILES[@]}
 
 if [[ "${FILE_COUNT}" -eq 0 ]]; then


### PR DESCRIPTION
## 概要

ワークフロー⑤（初期ファイル一括作成）の scaffold 定義に、AI ツール設定ファイル・IDE 設定ファイル・エディタ横断設定ファイルなど 11 ファイルを追加する。
また、JSON ファイルに `{}` を初期コンテンツとして設定できるよう、ファイルごとのコンテンツ指定に対応する。

## 変更内容

- feat: scaffold 定義に 11 ファイルを追加し、ファイルごとのコンテンツ指定に対応 [#496]

## 追加ファイル（11 ファイル）

| パス | 初期コンテンツ |
|---|---|
| `AGENTS.md` | 空 |
| `DESIGN.md` | 空 |
| `.mcp.json` | `{}` |
| `.claude/settings.json` | `{}` |
| `.agents/skills/.gitignore` | 空 |
| `.agents/skills/.gitkeep` | 空 |
| `.vscode/extensions.json` | `{}` |
| `.vscode/launch.json` | `{}` |
| `.vscode/settings.json` | `{}` |
| `.editorconfig` | 空 |
| `.gitattributes` | 空 |

## 動作確認

- [x] Bash スクリプトの構文確認（`bash -n`）
- [x] JSON 設定の構文確認（`jq empty`）
- [ ] YAML の構文確認 — 該当なし

## 影響範囲

- `scripts/config/repo-scaffold-definitions.json` — 11 エントリ追加（18 → 29）
- `scripts/lib/common.sh` — `FILE_CONTENT_MAP` 連想配列の導入、`create_files_via_pr` でコンテンツ指定対応
- `scripts/setup-repository-scaffold-files.sh` — JSON 定義から `content` フィールドを読み取り `FILE_CONTENT_MAP` に格納

## セルフレビュー

- [x] 変更差分をセルフレビューしました

## 補足

- `content` フィールドはオプション。未指定の場合は従来通り改行のみ（空ファイル）で作成される
- Health Files スクリプトは `FILE_CONTENT_MAP` を設定しないため、既存動作に影響なし

## 関連 Issue

Closes #496

## ブランチ

- 作業ブランチ: `issues/#496`
- マージ先ブランチ: `main`
- [x] 作業ブランチとマージ先ブランチの組み合わせを確認しました
