### PR TITLE
chore: .claude/settings.json の共通キー統一（repo-modernization-kit） [#499]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,7 +42,8 @@
   "permissions": {
     "allow": [
       "Bash(node:*)",
-      "Bash(python3:*)"
+      "Bash(python3:*)",
+      "Bash(npx:*)"
     ],
     "ask": [
       "Bash(git rm:*)",


### PR DESCRIPTION
repo-modernization-kit による自動最新化。指示: `instructions/settings-upsert.md`

Closes #499