### PR TITLE
chore: Renovate 共有 preset の導入（repo-modernization-kit） [#501]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>lurest-inc/repo-modernization-kit//renovate/default"]
+}


### PR DESCRIPTION
> [!WARNING]
> **部分完了です。承認されなかったツール要求が 1 件ありました。**
> 非対話実行では未承認の要求は承認プロンプトにならず黙って拒否され、実行はそのまま継続します。
> そのため、この PR には**指示の一部しか反映されていない可能性があります**。
> マージ前に下記を確認し、必要なら手当てしてください。

### 承認されなかったツール要求（1 件）

- `Bash` — `grep -ril "renovate\|dependabot" . --exclude-dir=.git --exclude=CHANGELOG.md 2>/dev/null | head -20; echo "exit=$?"`

### 対象リポジトリの生成AIによる報告

報告に `## 未完了（人間の対応が必要）` 節はありませんでした。別手段で達成できた可能性もありますが、機械的には区別できません。差分と下の報告末尾で判断してください。

<details><summary>報告の末尾（20 行）</summary>

    $ npx --yes --package renovate -- renovate-config-validator
     INFO: Validating renovate.json
     INFO: Config validated successfully
    ```
    
    `Validating renovate.json` の行に、手順 2 で作成したファイルが出ていることを確認済みです。
    
    - **検証に使われた renovate の版: `37.440.7`**
    
    ## 人間の判断が要ると思われる点
    
    1. **検証に使われた renovate の版が古い可能性があります。** 実行環境の node は `v26.6.0` ですが、`npx` が引いてきた renovate は `37.440.7` でした。最新の renovate は `engines.node` に偶数 LTS（22 / 24 系）を要求するため、**node 26 が条件を満たさず古い版へフォールバックした**と考えられます。`local>` プリセット記法自体は v35 以降でサポートされており今回の検証は有効ですが、最新スキーマでの再検証が必要なら node を 24 系に切り替えて再実行してください。
    
    2. **self-hosted Renovate は動いていません。** `.github/workflows/` 配下は `01`〜`08` の運用ワークフローと `release-please.yml` / `toc.yml` のみで、Renovate 関連のワークフローはありません。制約どおりワークフローは一切変更していません。
    
    3. **このリポジトリは Bash スクリプト集で `package.json` もロックファイルも存在しません。** そのため Renovate が実際に扱うのは主に `github-actions` マネージャー（`.github/workflows/` と `.github/actions/` の Action 版）になります。共有 preset の `github-actions` グループ設定がそのまま効き、まとめて 1 本の PR が出る想定です。npm 系の `packageRules`（devDependencies / dependencies のグループ分け）は当面空振りしますが、preset 側の設定なので害はありません。
    
    4. **release-please との関係。** このリポジトリは Conventional Commits ベースの release-please でバージョニングしています。共有 preset は `semanticCommitType: chore` / `semanticCommitScope: deps` を指定するため、Renovate の PR は `chore(deps): ...` になり、release-please のリリースノートには載らない扱いになります。意図と合っているかご確認ください。
    
    制約どおり、依存バージョンの更新・git 操作（コミット / push / PR 作成）・`.claude/` / `.codex/` の変更・ワークフローの変更は一切行っていません。

</details>

---

repo-modernization-kit による自動最新化。指示: `instructions/renovate-onboard.md`

Closes #501